### PR TITLE
docs: add .github/copilot-instructions.md

### DIFF
--- a/.github/agents/six-round-review.agent.md
+++ b/.github/agents/six-round-review.agent.md
@@ -1,0 +1,124 @@
+---
+description: Six Round Agent Review
+name: Six Round Review
+---
+
+# Six Round Review instructions
+
+---
+mode: ask
+description: Run a 6-lens code review of recent changes using specialized subagents for security, UX, best practices, data integrity, documentation, and test coverage
+---
+
+# Six-Model Code Review
+
+Run 6 parallel review passes over the recent work, each focused on a different expertise area. Use `git diff` to identify the changed files, then dispatch 6 subagents (use the `Explore` agent for each) with the review instructions below.
+
+## Setup
+
+1. Identify the diff range. Ask the user or infer from recent commits:
+   - `git --no-pager diff HEAD~N..HEAD --stat` (where N = number of commits in this work)
+   - Or diff against a specific base: `git --no-pager diff origin/staging..HEAD --stat`
+2. List the changed files and their purpose so each reviewer has context.
+3. Run all 6 reviews in parallel via subagents.
+
+## Review Lenses
+
+### 1. Security (OWASP / Auth / Injection)
+
+**Focus**: OWASP Top 10, auth bypass, injection, price manipulation, CSRF, rate limiting, information disclosure.
+
+**Check for**:
+- OData/SQL injection in any query construction (are GUIDs validated via assertGuid?)
+- Client-side price/amount values that the backend trusts without recalculating
+- Missing CSRF or auth checks on new/modified endpoints
+- Missing rate limiting on new endpoints
+- Secrets or tokens in responses, logs, or error messages
+- Integer overflow or negative value edge cases in financial calculations
+
+### 2. UX / Accessibility
+
+**Focus**: User-facing clarity, accessibility, i18n, error states, loading states.
+
+**Check for**:
+- Are new UI elements/labels clear to non-technical users (parents, admins)?
+- Accessibility: new form controls have labels, ARIA attributes, keyboard nav
+- i18n: are all user-visible strings in translation files? Are Spanish translations accurate?
+- Graceful degradation when API calls fail or return unexpected data
+- Mobile responsiveness of new UI elements
+- Consistent styling with existing patterns (Tailwind classes, color scheme)
+
+### 3. Best Practices / Code Quality
+
+**Focus**: Patterns, naming, DRY, separation of concerns, backward compatibility.
+
+**Check for**:
+- Does new code follow existing codebase patterns (BFF, data flow, naming)?
+- Constants in the right module? Shared logic not duplicated between frontend/backend?
+- Clean function signatures (no code smells like private properties on shared objects)?
+- Backward compatibility maintained for modified functions?
+- useMemo/useEffect dependency arrays correct in React components?
+- N+1 query patterns or unnecessary Dataverse round-trips?
+- Error handling: are new try/catch blocks consistent with existing patterns?
+
+### 4. Data Integrity / Business Logic
+
+**Focus**: Correctness of calculations, race conditions, edge cases, Stripe integration.
+
+**Check for**:
+- Do the calculations match the documented pricing scenarios exactly?
+- Race conditions: concurrent registrations, stale counts, double-charges
+- Stripe coupon/checkout amounts match backend calculations
+- Payment items record correct pre/post-discount amounts
+- Edge cases: zero-amount registrations, discount > subtotal, waitlisted campers
+- Dataverse query filters correct (status exclusions, role filters)
+- Withdrawal/cancellation impact on counts and pricing
+
+### 5. Documentation
+
+**Focus**: Accuracy, completeness, consistency across PRD and technical docs.
+
+**Check for**:
+- Do docs accurately describe the code behavior (no stale references)?
+- Are all price/rate values updated consistently (no leftover old values)?
+- New features documented: API response changes, new fields, new behaviors
+- Schema docs match actual Dataverse schema
+- PRD version and changelog updated if applicable
+- Implementation docs step numbering correct after insertions
+
+### 6. Test Coverage
+
+**Focus**: Test adequacy, coverage gaps, missing edge cases.
+
+**Check for**:
+- Are all documented pricing scenarios covered by unit tests?
+- New function signatures tested with all parameter variations?
+- Legacy behavior still tested (backward compatibility)?
+- What's NOT tested that should be: integration tests, frontend component tests, error paths, edge cases
+- Mock patterns consistent with existing test infrastructure?
+- Any test that would catch a regression if the sibling discount constant changed?
+
+## Output Format
+
+For each lens, report findings in priority order:
+
+| Severity | Meaning |
+|----------|---------|
+| CRITICAL | Must fix before merge — security vuln, data corruption, money bug |
+| HIGH | Should fix before merge — significant logic error, broken UX |
+| MEDIUM | Fix soon — code smell, missing test, unclear docs |
+| LOW | Nice to have — minor improvement, style nit |
+| INFO | Observation — no action needed, just awareness |
+
+After all 6 reports, provide a **consolidated action list** of items to fix, sorted by severity, with file references. Skip items that are pre-existing (not introduced by this diff).
+
+## Post-Review Workflow
+
+After presenting findings, execute these steps for every CRITICAL, HIGH, and MEDIUM item:
+
+1. **Open a GitHub issue** for each finding (or group tightly related findings into one issue). Title format: `[six-lens] <severity>: <short description>`. Label: `code-review`. Include the lens name, file references, and concrete fix description.
+2. **Fix the issue** — implement the change, run relevant tests.
+3. **Close the GitHub issue** when the fix is committed. Reference the issue in the commit message.
+4. **Document in commit** — commit message must reference the issue number and describe what was fixed.
+
+For LOW and INFO items, list them in a single "housekeeping" issue for future reference — do not block the merge on them.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# KillerPDF — Copilot instructions
+
+KillerPDF is a Windows-only WPF PDF editor distributed as a single, portable, Costura-bundled `KillerPDF.exe`. Targets `net48` so end users never need a runtime install. Built with the .NET 8+ SDK on Windows.
+
+## Build / publish / release
+
+- Dev build: `dotnet build` (from repo root). Project is `KillerPDF.csproj`.
+- Publish (single-EXE bundle): `dotnet publish -c Release` → output in `bin/Release/net48/publish/KillerPDF.exe`.
+  - Publish triggers the `BundleSource` MSBuild target which runs `build/bundle-source.ps1` to produce `KillerPDF-<Version>-src.zip` (GPL3 corresponding source) next to the EXE. It uses `git ls-files`, so an unstaged file will not be included.
+  - Publish uses `Properties/PublishProfiles/FolderProfile1.pubxml` (net48, win-x64).
+- Full release (Windows only, requires Certum cert + Windows SDK signtool): `./release.ps1` (or `./release.ps1 -SkipSign` for a test run). Builds, signs, prints SHA256, and reminds you to paste it into `pdf-landing/index.html` and the external `killer-tools-site` repo.
+- No test suite or linter is configured. `dotnet build` warnings are the only lint signal — do not introduce new warnings (nullable reference types are enabled).
+
+## Cross-platform caveat
+
+The repo lives on macOS in this environment but the project **only builds on Windows** (`UseWPF=true`, `net48`, `win-x64`, native `pdfium.dll` P/Invoke). Do not expect `dotnet build` to succeed here; rely on careful reading instead of compile checks, or hand work off to a Windows runner.
+
+## Architecture
+
+- **Single-window WPF app**, no MVVM, no DI. Everything lives in two files:
+  - `MainWindow.xaml.cs` (~3.5k lines) is intentionally a god-class that owns all UI state, tools, rendering, search, signatures, save/flatten, install/uninstall, dialogs, etc. New UI features go here unless there is a strong reason to split.
+  - `EditingTypes.cs` holds the annotation/signature data model (`PageAnnotation` and subclasses: `TextAnnotation`, `InkAnnotation`, `HighlightAnnotation`, `TextEditAnnotation`, `SignatureAnnotation`; plus `SavedSignature`/`SerializablePoint` for JSON persistence).
+- **Rendering vs. editing split** — three PDF libraries, each used for what it is best at. Don't swap them:
+  - **Docnet.Core (PDFium)** — high-quality page raster for on-screen rendering and the "Save Flattened" 150 DPI export. Native `pdfium.dll` is embedded via Costura (`FodyWeavers.xml` → `Unmanaged64Assemblies`).
+  - **PdfSharpCore** — page geometry, merging/splitting, and writing annotations into the saved PDF.
+  - **PdfPig** (`UglyToad.PdfPig`, aliased as `PdfPigDoc`) — text extraction for search, drag-select copy, and font-name matching during inline text edits.
+- **Annotation model** — `_annotations` is `Dictionary<int pageIndex, List<PageAnnotation>>`. The on-screen `AnnotationCanvas` is a transient WPF overlay; on save, annotations are baked into the PDF via PdfSharpCore. "Save Flattened" instead rasterizes pages through PDFium so nothing remains editable.
+- **Custom chrome** — `WindowStyle=None` + `AllowsTransparency=True`. There is a `WM_GETMINMAXINFO` hook in `MainWindow_SourceInitialized` so maximize doesn't cover the taskbar; preserve it if you touch window sizing. All dialogs are custom dark-themed windows — do not use `MessageBox.Show` or `OpenFileDialog`'s default chrome for new UI; match the existing pattern.
+- **Self-installer** — first-launch Install/Run dialog installs per-user to `%LOCALAPPDATA%\Programs\KillerPDF\` (no UAC), registers PDF file association, and writes an Add/Remove Programs entry; uninstall self-deletes via a deferred batch file. CLI: `KillerPDF.exe "file.pdf"` opens directly (used by the file association).
+- **Password-protected PDFs** — prompt for password, write a decrypted copy to a temp file, edit/render against that for the session.
+- **Signatures** persist to `signatures.json` next to the EXE (`AppDomain.CurrentDomain.BaseDirectory`). Both drawn (`Strokes`) and imported-image (`ImageData` = base64 PNG) variants share the `SavedSignature` type — `ImageData != null` is the discriminator.
+
+## Conventions
+
+- `net48` target with `LangVersion=latest` + `PolySharp` polyfills. Modern C# syntax is fine, **but** runtime APIs introduced after .NET Framework 4.8 are not. Notably: do not use `Math.Clamp` — use `Math.Min`/`Math.Max` (this regressed once; see CHANGELOG 1.1.0).
+- Nullable reference types are enabled project-wide. New code must be null-annotated; do not silence `CS8602` etc. with `!` unless the invariant is genuinely guaranteed.
+- XAML-defined controls that the codegen can't resolve are re-fetched in the constructor via `FindName(...)!` and stored in `_camelCase` fields (see the block under `// Manual element refs`). Follow that pattern for new named XAML elements rather than fighting the generator.
+- UI palette is centralized in `MainWindow.xaml` resources (`BgDark`, `BgPanel`, `AccentGreen`, `DangerRed`, etc.). Use those brushes; don't hardcode new hex colors. Toolbar glyphs are `Segoe MDL2 Assets`.
+- Track unsaved edits by setting `_isDirty = true` on any change that mutates the document, and route close/open paths through the existing dirty-check prompts.
+- Versioning: bump `<Version>`, `<AssemblyVersion>`, `<FileVersion>` in `KillerPDF.csproj` together, add a `## [x.y.z] - YYYY-MM-DD` section to `CHANGELOG.md` (Keep a Changelog format, SemVer), and update the compare links at the bottom.


### PR DESCRIPTION
Adds an authoritative `.github/copilot-instructions.md` so future Copilot/AI-assistant sessions don't have to rediscover the project's structure each time.

Captures:
- Build / publish / release commands (`dotnet publish -c Release`, `./release.ps1`)
- The Windows-only build constraint (net48 + WPF + native pdfium.dll)
- The three-PDF-library architecture (Docnet/PDFium for raster, PdfSharpCore for write/merge, PdfPig for text)
- Single-window, no-MVVM-yet design with the god-class `MainWindow.xaml.cs` and the `EditingTypes.cs` data model
- WPF custom-chrome pattern (`WindowStyle=None` + `WM_GETMINMAXINFO` hook) and self-installer behavior
- Conventions (net48 runtime API limits — no `Math.Clamp` per CHANGELOG 1.1.0; nullable enabled; `FindName` pattern for XAML refs; centralized brush resources; version-bump checklist)

No behavioral changes. Documentation only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>