### PR TITLE
Add global crash diagnostics

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -3,11 +3,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Windows.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.Win32;
+using KillerPDF.Diagnostics;
 
 namespace KillerPDF
 {
@@ -45,6 +48,10 @@ namespace KillerPDF
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnDomainUnhandledException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
             base.OnStartup(e);
 
             // Prevent WPF from auto-shutting down when the launcher dialog closes
@@ -110,6 +117,35 @@ namespace KillerPDF
             // Hand shutdown responsibility back to the normal window-close behaviour
             ShutdownMode = ShutdownMode.OnLastWindowClose;
             new MainWindow().Show();
+        }
+
+        // ============================================================
+        // Crash handling
+        // ============================================================
+
+        private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            var report = CrashReporter.Report(e.Exception, "UI thread");
+            bool shouldContinue = CrashDialog.ShowCrash(report);
+            e.Handled = report.Recoverable && shouldContinue;
+
+            if (!e.Handled)
+                Shutdown(1);
+        }
+
+        private void OnDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            var exception = e.ExceptionObject as Exception
+                ?? new InvalidOperationException("A non-Exception object was thrown.");
+            var report = CrashReporter.Report(exception, "AppDomain unhandled exception");
+            CrashDialog.ShowCrash(report);
+        }
+
+        private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            var report = CrashReporter.Report(e.Exception, "Unobserved task exception");
+            CrashDialog.ShowCrash(report);
+            e.SetObserved();
         }
 
         // ============================================================

--- a/Diagnostics/CrashDialog.cs
+++ b/Diagnostics/CrashDialog.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace KillerPDF.Diagnostics
+{
+    public sealed class CrashDialog : Window
+    {
+        private static int _showing;
+        private readonly CrashReport _report;
+        private bool _continueRequested;
+
+        private CrashDialog(CrashReport report)
+        {
+            _report = report;
+            Title = "KillerPDF crash report";
+            Width = 720;
+            Height = 520;
+            MinWidth = 560;
+            MinHeight = 420;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            ResizeMode = ResizeMode.CanResize;
+            Background = Brush(0x1a, 0x1a, 0x1a);
+            Foreground = Brushes.White;
+            Content = BuildContent();
+        }
+
+        public bool ContinueRequested => _continueRequested;
+
+        public static bool ShowCrash(CrashReport report)
+        {
+            if (Interlocked.Exchange(ref _showing, 1) != 0)
+                return false;
+
+            try
+            {
+                if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
+                    return ShowCrashOnCurrentThread(report);
+
+                bool shouldContinue = false;
+                var thread = new Thread(() => shouldContinue = ShowCrashOnCurrentThread(report));
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.IsBackground = true;
+                thread.Start();
+                thread.Join();
+                return shouldContinue;
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _showing, 0);
+            }
+        }
+
+        private static bool ShowCrashOnCurrentThread(CrashReport report)
+        {
+            try
+            {
+                var dialog = new CrashDialog(report);
+                dialog.ShowDialog();
+                return dialog.ContinueRequested;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private UIElement BuildContent()
+        {
+            var root = new Grid { Margin = new Thickness(18) };
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var title = new TextBlock
+            {
+                Text = _report.Recoverable ? "KillerPDF hit an error" : "KillerPDF must close",
+                FontSize = 24,
+                FontWeight = FontWeights.Bold,
+                Foreground = Brush(0x4a, 0xde, 0x80),
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            root.Children.Add(title);
+
+            var summary = new TextBlock
+            {
+                Text = _report.Summary,
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = Brushes.White,
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            Grid.SetRow(summary, 1);
+            root.Children.Add(summary);
+
+            var details = new Expander
+            {
+                Header = "Details",
+                IsExpanded = true,
+                Foreground = Brushes.White,
+                Background = Brush(0x25, 0x25, 0x25),
+                Content = new TextBox
+                {
+                    Text = _report.Details,
+                    IsReadOnly = true,
+                    AcceptsReturn = true,
+                    AcceptsTab = true,
+                    TextWrapping = TextWrapping.NoWrap,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    FontFamily = new FontFamily("Consolas"),
+                    FontSize = 12,
+                    Background = Brush(0x10, 0x10, 0x10),
+                    Foreground = Brushes.White,
+                    BorderBrush = Brush(0x44, 0x44, 0x44)
+                }
+            };
+            Grid.SetRow(details, 2);
+            root.Children.Add(details);
+
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 14, 0, 0)
+            };
+
+            buttons.Children.Add(MakeButton("Copy report", CopyReport, true));
+            buttons.Children.Add(MakeButton("Open log folder", OpenLogFolder, true));
+            buttons.Children.Add(MakeButton("Continue", Continue, _report.Recoverable));
+            buttons.Children.Add(MakeButton("Quit", Quit, true));
+
+            Grid.SetRow(buttons, 3);
+            root.Children.Add(buttons);
+
+            return root;
+        }
+
+        private Button MakeButton(string text, RoutedEventHandler handler, bool isEnabled)
+        {
+            var button = new Button
+            {
+                Content = text,
+                MinWidth = 96,
+                Margin = new Thickness(8, 0, 0, 0),
+                Padding = new Thickness(10, 6, 10, 6),
+                IsEnabled = isEnabled,
+                Background = text == "Quit" ? Brush(0xc4, 0x2b, 0x1c) : Brush(0x30, 0x30, 0x30),
+                Foreground = Brushes.White,
+                BorderBrush = Brush(0x55, 0x55, 0x55),
+                Cursor = Cursors.Hand
+            };
+            button.Click += handler;
+            return button;
+        }
+
+        private void CopyReport(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                string logPath = _report.LogPath ?? "(log file unavailable)";
+                Clipboard.SetText($"Log: {logPath}{Environment.NewLine}{_report.Summary}");
+            }
+            catch
+            {
+            }
+        }
+
+        private void OpenLogFolder(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                Directory.CreateDirectory(_report.LogDirectory);
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = _report.LogDirectory,
+                    UseShellExecute = true
+                });
+            }
+            catch
+            {
+            }
+        }
+
+        private void Continue(object sender, RoutedEventArgs e)
+        {
+            if (!_report.Recoverable)
+                return;
+
+            _continueRequested = true;
+            Close();
+        }
+
+        private void Quit(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var application = Application.Current;
+                if (application?.Dispatcher is not null && !application.Dispatcher.CheckAccess())
+                    application.Dispatcher.BeginInvoke(new Action(() => application.Shutdown(1)));
+                else
+                    application?.Shutdown(1);
+            }
+            catch
+            {
+            }
+
+            Close();
+        }
+
+        private static SolidColorBrush Brush(byte r, byte g, byte b)
+        {
+            var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
+            brush.Freeze();
+            return brush;
+        }
+    }
+}

--- a/Diagnostics/CrashReporter.cs
+++ b/Diagnostics/CrashReporter.cs
@@ -1,0 +1,281 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Markup;
+
+namespace KillerPDF.Diagnostics
+{
+    public sealed class CrashReport
+    {
+        public CrashReport(Exception exception, string source, string? logPath, string logDirectory, bool recoverable, string summary, string details)
+        {
+            Exception = exception;
+            Source = source;
+            LogPath = logPath;
+            LogDirectory = logDirectory;
+            Recoverable = recoverable;
+            Summary = summary;
+            Details = details;
+        }
+
+        public Exception Exception { get; }
+        public string Source { get; }
+        public string? LogPath { get; }
+        public string LogDirectory { get; }
+        public bool Recoverable { get; }
+        public string Summary { get; }
+        public string Details { get; }
+    }
+
+    public static class CrashReporter
+    {
+        private const long MaxLogDirectoryBytes = 20L * 1024L * 1024L;
+        private static int _writing;
+
+        // TODO(#26): Feed this from MainWindow.SetStatus(...) after the MVVM refactor in #18/#21 lands.
+        public static StatusRingBuffer StatusMessages { get; } = new StatusRingBuffer(50);
+
+        public static string LogDirectory => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "KillerPDF",
+            "Logs");
+
+        public static CrashReport Report(Exception exception, string source)
+        {
+            if (Interlocked.Exchange(ref _writing, 1) != 0)
+            {
+                string reentrantSummary = $"{source}: {exception.GetType().FullName}: crash reporter already active";
+                return new CrashReport(exception, source, null, LogDirectory, false, reentrantSummary, reentrantSummary);
+            }
+
+            bool recoverable = false;
+            string summary = "Crash report unavailable.";
+            string details = "Crash report unavailable.";
+            string? logPath = null;
+
+            try
+            {
+                recoverable = IsRecoverable(exception);
+                summary = BuildSummary(exception, source, recoverable);
+                details = BuildDetails(exception, source, recoverable);
+
+                Directory.CreateDirectory(LogDirectory);
+                logPath = Path.Combine(LogDirectory, $"crash-{DateTime.Now:yyyyMMdd-HHmmss-fff}.log");
+                File.WriteAllText(logPath, details, Encoding.UTF8);
+                TrimLogDirectory();
+            }
+            catch
+            {
+                logPath = null;
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _writing, 0);
+            }
+
+            return new CrashReport(exception, source, logPath, LogDirectory, recoverable, summary, details);
+        }
+
+        public static bool IsRecoverable(Exception exception)
+        {
+            if (ContainsFatalException(exception) || ContainsNativePdfStack(exception))
+                return false;
+
+            if (ContainsRecoverableException(exception))
+                return true;
+
+            return false;
+        }
+
+        private static bool ContainsFatalException(Exception exception)
+        {
+            for (Exception? current = exception; current is not null; current = current.InnerException)
+            {
+                if (current is OutOfMemoryException || current is AccessViolationException || current is StackOverflowException)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool ContainsRecoverableException(Exception exception)
+        {
+            for (Exception? current = exception; current is not null; current = current.InnerException)
+            {
+                if (current is IOException ||
+                    current is UnauthorizedAccessException ||
+                    current is ArgumentException ||
+                    current is XamlParseException ||
+                    current is InvalidOperationException)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool ContainsNativePdfStack(Exception exception)
+        {
+            for (Exception? current = exception; current is not null; current = current.InnerException)
+            {
+                string stack = current.StackTrace ?? string.Empty;
+                if (stack.IndexOf("Docnet.", StringComparison.Ordinal) >= 0 ||
+                    stack.IndexOf("PDFium", StringComparison.Ordinal) >= 0)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static string BuildSummary(Exception exception, string source, bool recoverable)
+        {
+            return $"{source}: {exception.GetType().FullName}: {Sanitize(exception.Message)} ({(recoverable ? "recoverable" : "fatal")})";
+        }
+
+        private static string BuildDetails(Exception exception, string source, bool recoverable)
+        {
+            var sb = new StringBuilder();
+            var assembly = Assembly.GetExecutingAssembly().GetName();
+
+            sb.AppendLine("KillerPDF crash report");
+            sb.AppendLine($"Timestamp: {DateTimeOffset.Now:O}");
+            sb.AppendLine($"Source: {source}");
+            sb.AppendLine($"Recoverable: {(recoverable ? "yes" : "no")}");
+            sb.AppendLine($"App version: {assembly.Version}");
+            sb.AppendLine($"OS version: {Environment.OSVersion}");
+            sb.AppendLine($"CLR version: {Environment.Version}");
+            sb.AppendLine($"Working set: {Environment.WorkingSet} bytes");
+            AppendDocumentState(sb);
+            AppendStatusMessages(sb);
+            sb.AppendLine();
+            sb.AppendLine("Exception chain:");
+            AppendExceptionChain(sb, exception);
+
+            return sb.ToString();
+        }
+
+        private static void AppendDocumentState(StringBuilder sb)
+        {
+            bool documentOpen = false;
+            bool dirty = false;
+
+            try
+            {
+                Window? mainWindow = Application.Current?.MainWindow;
+                if (mainWindow is not null)
+                {
+                    Type type = mainWindow.GetType();
+                    const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+                    object? doc = type.GetField("_doc", flags)?.GetValue(mainWindow);
+                    object? dirtyValue = type.GetField("_isDirty", flags)?.GetValue(mainWindow);
+
+                    documentOpen = doc is not null;
+                    dirty = dirtyValue is bool b && b;
+                }
+            }
+            catch
+            {
+                sb.AppendLine("Document state: unavailable");
+                return;
+            }
+
+            sb.AppendLine($"Document state: (document open: {(documentOpen ? "yes" : "no")}, dirty: {(dirty ? "yes" : "no")})");
+        }
+
+        private static void AppendStatusMessages(StringBuilder sb)
+        {
+            string[] statuses;
+
+            try
+            {
+                statuses = StatusMessages.Snapshot();
+            }
+            catch
+            {
+                statuses = Array.Empty<string>();
+            }
+
+            sb.AppendLine("Recent status messages:");
+            if (statuses.Length == 0)
+            {
+                sb.AppendLine("  (none captured)");
+                return;
+            }
+
+            foreach (string status in statuses)
+                sb.AppendLine("  " + Sanitize(status));
+        }
+
+        private static void AppendExceptionChain(StringBuilder sb, Exception exception)
+        {
+            int depth = 0;
+            for (Exception? current = exception; current is not null; current = current.InnerException)
+            {
+                sb.AppendLine();
+                sb.AppendLine($"[{depth}] {current.GetType().FullName}");
+                sb.AppendLine(Sanitize(current.Message));
+                sb.AppendLine(Sanitize(current.StackTrace ?? "(no stack trace)"));
+                depth++;
+            }
+        }
+
+        private static string Sanitize(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
+            string sanitized = value;
+            sanitized = Regex.Replace(sanitized, @"(?i)(password\s*[:=]\s*)\S+", "$1[redacted]");
+            sanitized = Regex.Replace(sanitized, @"(?i)(passphrase\s*[:=]\s*)\S+", "$1[redacted]");
+            sanitized = Regex.Replace(sanitized, @"\\[^\s:;]+(?:\\[^\s:;]+)+", "[path redacted]");
+            sanitized = Regex.Replace(sanitized, @"[A-Za-z]:\\[^\r\n:;]+", "[path redacted]");
+            sanitized = Regex.Replace(sanitized, @"(?m) in /[^\r\n]+:line \d+", " in [path redacted]");
+            sanitized = Regex.Replace(sanitized, @"(?<!/)/[^\s\0]+", "[path redacted]");
+            return sanitized;
+        }
+
+        private static void TrimLogDirectory()
+        {
+            try
+            {
+                var directory = new DirectoryInfo(LogDirectory);
+                if (!directory.Exists)
+                    return;
+
+                FileInfo[] files = directory.GetFiles("crash-*.log")
+                    .OrderBy(file => file.CreationTimeUtc)
+                    .ToArray();
+                long totalBytes = files.Sum(file => SafeLength(file));
+
+                foreach (FileInfo file in files)
+                {
+                    if (totalBytes <= MaxLogDirectoryBytes)
+                        break;
+
+                    long length = SafeLength(file);
+                    try
+                    {
+                        file.Delete();
+                        totalBytes -= length;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static long SafeLength(FileInfo file)
+        {
+            try { return file.Length; }
+            catch { return 0; }
+        }
+    }
+}

--- a/Diagnostics/StatusRingBuffer.cs
+++ b/Diagnostics/StatusRingBuffer.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace KillerPDF.Diagnostics
+{
+    public sealed class StatusRingBuffer
+    {
+        private readonly string?[] _entries;
+        private readonly object _gate = new object();
+        private int _next;
+        private int _count;
+
+        public StatusRingBuffer(int capacity = 50)
+        {
+            if (capacity <= 0)
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+
+            _entries = new string?[capacity];
+        }
+
+        public int Capacity => _entries.Length;
+
+        public void Add(string? message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+                return;
+
+            lock (_gate)
+            {
+                _entries[_next] = $"{DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss.fff zzz} {message}";
+                _next = (_next + 1) % _entries.Length;
+                _count = Math.Min(_count + 1, _entries.Length);
+            }
+        }
+
+        public string[] Snapshot()
+        {
+            lock (_gate)
+            {
+                var result = new string[_count];
+                int start = (_next - _count + _entries.Length) % _entries.Length;
+
+                for (int i = 0; i < _count; i++)
+                    result[i] = _entries[(start + i) % _entries.Length] ?? string.Empty;
+
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refs #26 (foundation; status-ring wiring + Report-on-GitHub button + temp-file cleanup deferred)

## Summary
- Wires UI-thread, AppDomain, and unobserved-task crash handlers during app startup.
- Adds local-only crash logs under `%LOCALAPPDATA%\KillerPDF\Logs` with a 20 MB retention cap.
- Adds a minimal dark-themed crash dialog with copy/open-folder/continue/quit actions.
- Adds a 50-entry status ring buffer for future status message capture.

## Deferred
- Wiring `StatusRingBuffer` to `MainWindow.xaml.cs.SetStatus(...)` until after #18/#21.
- The `Report on GitHub` button/deep-link follow-up.
- Encrypted-PDF temp file `try/finally` registration pending #25 installer/temp-path work.
- `FileOptions.DeleteOnClose` temp-file wiring pending #25.

## Validation
- `git diff --check`
- Code-review agent completed cleanly after review fixes.
- The code was not built on a Windows host and requires a maintainer build before merge.