### PR TITLE
Harden MainWindow accessibility

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -9,7 +9,23 @@
         WindowStyle="None"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip"
-        Background="#1a1a1a">
+        Background="#1a1a1a"
+        KeyboardNavigation.TabNavigation="Continue"
+        KeyboardNavigation.ControlTabNavigation="Continue">
+
+    <Window.CommandBindings>
+        <CommandBinding Command="{x:Static ApplicationCommands.Open}" Executed="OpenCommand_Executed"/>
+        <CommandBinding Command="{x:Static ApplicationCommands.Save}" Executed="SaveCommand_Executed"/>
+        <CommandBinding Command="{x:Static ApplicationCommands.Print}" Executed="PrintCommand_Executed"/>
+        <CommandBinding Command="{x:Static ApplicationCommands.Find}" Executed="FindCommand_Executed"/>
+    </Window.CommandBindings>
+
+    <Window.InputBindings>
+        <KeyBinding Key="O" Modifiers="Control" Command="{x:Static ApplicationCommands.Open}"/>
+        <KeyBinding Key="S" Modifiers="Control" Command="{x:Static ApplicationCommands.Save}"/>
+        <KeyBinding Key="P" Modifiers="Control" Command="{x:Static ApplicationCommands.Print}"/>
+        <KeyBinding Key="F" Modifiers="Control" Command="{x:Static ApplicationCommands.Find}"/>
+    </Window.InputBindings>
 
     <Window.Resources>
         <!-- Killer Tools dark/green theme -->
@@ -23,6 +39,17 @@
         <SolidColorBrush x:Key="TextSecondary" Color="#888888"/>
         <SolidColorBrush x:Key="DangerRed" Color="#ef4444"/>
 
+        <Style x:Key="VisibleFocusVisual" TargetType="Control">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Control">
+                        <Rectangle Margin="1" Stroke="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                                   StrokeThickness="2" StrokeDashArray="2 1" SnapsToDevicePixels="True"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- Toolbar button -->
         <Style x:Key="ToolbarButton" TargetType="Button">
             <Setter Property="Background" Value="Transparent"/>
@@ -32,6 +59,7 @@
             <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
             <Setter Property="Width" Value="36"/>
             <Setter Property="Height" Value="32"/>
             <Setter Property="Template">
@@ -72,6 +100,7 @@
             <Setter Property="Height" Value="36"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -241,6 +270,7 @@
             <Setter Property="FontFamily" Value="Consolas"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ComboBoxItem">
@@ -251,12 +281,12 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsHighlighted" Value="True">
-                                <Setter TargetName="ItemBd" Property="Background" Value="{StaticResource AccentGreenDim}"/>
-                                <Setter Property="Foreground" Value="{StaticResource AccentGreen}"/>
+                                <Setter TargetName="ItemBd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
                             </Trigger>
                             <Trigger Property="IsSelected" Value="True">
-                                <Setter TargetName="ItemBd" Property="Background" Value="{StaticResource AccentGreenDim}"/>
-                                <Setter Property="Foreground" Value="{StaticResource AccentGreen}"/>
+                                <Setter TargetName="ItemBd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -274,6 +304,7 @@
             <Setter Property="FontFamily" Value="Consolas"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
             <Setter Property="ItemContainerStyle" Value="{StaticResource DarkComboItem}"/>
             <Setter Property="Template">
                 <Setter.Value>
@@ -378,12 +409,16 @@
             <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
             <Setter Property="FontFamily" Value="Consolas"/>
             <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
         </Style>
         <Style TargetType="ListBoxItem">
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
+            <Setter Property="AutomationProperties.Name" Value="{Binding}"/>
+            <Setter Property="AutomationProperties.HelpText" Value="PDF page item"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ListBoxItem">
@@ -399,8 +434,8 @@
                                 <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgHover}"/>
                             </Trigger>
                             <Trigger Property="IsSelected" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentGreenDim}"/>
-                                <Setter Property="Foreground" Value="{StaticResource AccentGreen}"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -416,6 +451,7 @@
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FocusVisualStyle" Value="{StaticResource VisibleFocusVisual}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -441,7 +477,7 @@
         </Style>
     </Window.Resources>
 
-    <Grid>
+    <Grid KeyboardNavigation.TabNavigation="Continue">
         <Grid.RowDefinitions>
             <RowDefinition Height="36"/>
             <RowDefinition Height="Auto"/>
@@ -453,72 +489,95 @@
         <Border Grid.Row="0" Background="#111111" BorderBrush="{StaticResource BorderDim}" BorderThickness="0,0,0,1"
                 MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
             <Grid>
+                <Grid x:Name="ChromeA11yLabels" Width="0" Height="0" IsHitTestVisible="False" Focusable="False" Opacity="0">
+                    <TextBlock x:Name="MinimizeButtonLabel" Text="Minimize window"/>
+                    <TextBlock x:Name="MaximizeButtonLabel" Text="Maximize or restore window"/>
+                    <TextBlock x:Name="CloseWindowButtonLabel" Text="Close window"/>
+                </Grid>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="16,0,0,0">
                     <TextBlock Text="Killer" FontFamily="Segoe UI" FontWeight="Bold" FontSize="16" Foreground="{StaticResource TextPrimary}"/>
                     <TextBlock Text="PDF" FontFamily="Segoe UI" FontWeight="Bold" FontSize="16" Foreground="{StaticResource AccentGreen}"/>
                     <TextBlock Text="" x:Name="FileNameLabel" VerticalAlignment="Center" Margin="16,0,0,0"
-                               Foreground="{StaticResource TextSecondary}" FontFamily="Consolas" FontSize="11"/>
+                               Foreground="{StaticResource TextSecondary}" FontFamily="Consolas" FontSize="11"
+                               AutomationProperties.Name="Current file"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Content="&#x2015;" Click="MinimizeBtn_Click" Style="{StaticResource ChromeButton}"/>
-                    <Button Content="&#x25A1;" Click="MaximizeBtn_Click" Style="{StaticResource ChromeButton}"/>
-                    <Button Content="&#x2715;" Click="CloseBtn_Click" Style="{StaticResource ChromeCloseButton}"/>
+                    <Button Content="&#x2015;" Click="MinimizeBtn_Click" Style="{StaticResource ChromeButton}"
+                            KeyboardNavigation.TabIndex="0" AutomationProperties.Name="Minimize window"
+                            AutomationProperties.HelpText="Minimizes KillerPDF to the taskbar"
+                            AutomationProperties.LabeledBy="{Binding ElementName=MinimizeButtonLabel}"/>
+                    <Button Content="&#x25A1;" Click="MaximizeBtn_Click" Style="{StaticResource ChromeButton}"
+                            KeyboardNavigation.TabIndex="1" AutomationProperties.Name="Maximize or restore window"
+                            AutomationProperties.HelpText="Toggles between maximized and restored window size"
+                            AutomationProperties.LabeledBy="{Binding ElementName=MaximizeButtonLabel}"/>
+                    <Button Content="&#x2715;" Click="CloseBtn_Click" Style="{StaticResource ChromeCloseButton}"
+                            KeyboardNavigation.TabIndex="2" AutomationProperties.Name="Close window"
+                            AutomationProperties.HelpText="Closes KillerPDF"
+                            AutomationProperties.LabeledBy="{Binding ElementName=CloseWindowButtonLabel}"/>
                 </StackPanel>
             </Grid>
         </Border>
 
         <!-- Toolbar -->
-        <Border Grid.Row="1" Background="#111111" BorderBrush="{StaticResource BorderDim}" BorderThickness="0,0,0,1" Padding="4,2">
+        <Border Grid.Row="1" Background="#111111" BorderBrush="{StaticResource BorderDim}" BorderThickness="0,0,0,1" Padding="4,2"
+                KeyboardNavigation.TabNavigation="Continue">
             <Grid>
+                <Grid x:Name="ToolbarA11yLabels" Width="0" Height="0" IsHitTestVisible="False" Focusable="False" Opacity="0">
+                    <TextBlock x:Name="OpenButtonLabel" Text="Open"/><TextBlock x:Name="CloseFileButtonLabel" Text="Close file"/>
+                    <TextBlock x:Name="MergeButtonLabel" Text="Merge PDFs"/><TextBlock x:Name="SplitButtonLabel" Text="Extract pages"/>
+                    <TextBlock x:Name="DeleteButtonLabel" Text="Delete selected pages"/><TextBlock x:Name="MoveUpButtonLabel" Text="Move page up"/>
+                    <TextBlock x:Name="MoveDownButtonLabel" Text="Move page down"/><TextBlock x:Name="SaveAsButtonLabel" Text="Save as"/>
+                    <TextBlock x:Name="SaveFlattenedButtonLabel" Text="Save flattened PDF"/><TextBlock x:Name="PrintButtonLabel" Text="Print"/>
+                    <TextBlock x:Name="SelectToolButtonLabel" Text="Select tool"/><TextBlock x:Name="TextToolButtonLabel" Text="Text tool"/>
+                    <TextBlock x:Name="HighlightToolButtonLabel" Text="Highlight tool"/><TextBlock x:Name="DrawToolButtonLabel" Text="Draw tool"/>
+                    <TextBlock x:Name="SignatureButtonLabel" Text="Signature tool"/><TextBlock x:Name="UndoButtonLabel" Text="Undo last annotation"/>
+                    <TextBlock x:Name="ClearAnnotationsButtonLabel" Text="Clear annotations"/><TextBlock x:Name="ZoomLabel" Text="Zoom level"/>
+                </Grid>
                 <!-- File operations -->
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
-                    <Button Content="&#xE8DA;" Style="{StaticResource ToolbarButton}" Click="Open_Click" ToolTip="Open (Ctrl+O)"/>
-                    <Button x:Name="CloseFileBtn" Content="&#xE711;" Style="{StaticResource ToolbarButton}" Click="CloseFile_Click" ToolTip="Close File (Ctrl+W)" IsEnabled="False"/>
+                    <Button Content="&#xE8DA;" Style="{StaticResource ToolbarButton}" Click="Open_Click" ToolTip="Open (Ctrl+O, Alt+O)" KeyboardNavigation.TabIndex="3" AutomationProperties.Name="Open" AutomationProperties.HelpText="Open a PDF file. Shortcut Ctrl+O. Access key Alt+O." AutomationProperties.AccessKey="O" AutomationProperties.LabeledBy="{Binding ElementName=OpenButtonLabel}"/>
+                    <Button x:Name="CloseFileBtn" Content="&#xE711;" Style="{StaticResource ToolbarButton}" Click="CloseFile_Click" ToolTip="Close File (Ctrl+W, Alt+W)" IsEnabled="False" KeyboardNavigation.TabIndex="4" AutomationProperties.Name="Close file" AutomationProperties.HelpText="Close the current PDF and return to the start view. Shortcut Ctrl+W. Access key Alt+W." AutomationProperties.AccessKey="W" AutomationProperties.LabeledBy="{Binding ElementName=CloseFileButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button Content="&#xE710;" Style="{StaticResource ToolbarButton}" Click="Merge_Click" ToolTip="Merge PDFs (combine additional PDFs into this one)"/>
-                    <Button Content="&#xE8B1;" Style="{StaticResource ToolbarButton}" Click="Split_Click" ToolTip="Extract Pages (save selected pages to a new PDF)"/>
+                    <Button Content="&#xE710;" Style="{StaticResource ToolbarButton}" Click="Merge_Click" ToolTip="Merge PDFs (Alt+M)" KeyboardNavigation.TabIndex="5" AutomationProperties.Name="Merge PDFs" AutomationProperties.HelpText="Combine additional PDFs into this document. Access key Alt+M." AutomationProperties.AccessKey="M" AutomationProperties.LabeledBy="{Binding ElementName=MergeButtonLabel}"/>
+                    <Button Content="&#xE8B1;" Style="{StaticResource ToolbarButton}" Click="Split_Click" ToolTip="Extract Pages (Alt+E)" KeyboardNavigation.TabIndex="6" AutomationProperties.Name="Extract pages" AutomationProperties.HelpText="Save selected pages to a new PDF. Access key Alt+E." AutomationProperties.AccessKey="E" AutomationProperties.LabeledBy="{Binding ElementName=SplitButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button Content="&#xE8C6;" Style="{StaticResource ToolbarButton}" Click="Delete_Click" ToolTip="Delete Selected Pages"/>
+                    <Button Content="&#xE8C6;" Style="{StaticResource ToolbarButton}" Click="Delete_Click" ToolTip="Delete Selected Pages (Alt+D)" KeyboardNavigation.TabIndex="7" AutomationProperties.Name="Delete selected pages" AutomationProperties.HelpText="Delete the selected pages from the current PDF. Access key Alt+D." AutomationProperties.AccessKey="D" AutomationProperties.LabeledBy="{Binding ElementName=DeleteButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button Content="&#xE74A;" Style="{StaticResource ToolbarButton}" Click="MoveUp_Click" ToolTip="Move Page Up (reorder)"/>
-                    <Button Content="&#xE74B;" Style="{StaticResource ToolbarButton}" Click="MoveDown_Click" ToolTip="Move Page Down (reorder)"/>
+                    <Button Content="&#xE74A;" Style="{StaticResource ToolbarButton}" Click="MoveUp_Click" ToolTip="Move Page Up (Alt+U)" KeyboardNavigation.TabIndex="8" AutomationProperties.Name="Move page up" AutomationProperties.HelpText="Move the selected page earlier in the document. Access key Alt+U." AutomationProperties.AccessKey="U" AutomationProperties.LabeledBy="{Binding ElementName=MoveUpButtonLabel}"/>
+                    <Button Content="&#xE74B;" Style="{StaticResource ToolbarButton}" Click="MoveDown_Click" ToolTip="Move Page Down (Alt+N)" KeyboardNavigation.TabIndex="9" AutomationProperties.Name="Move page down" AutomationProperties.HelpText="Move the selected page later in the document. Access key Alt+N." AutomationProperties.AccessKey="N" AutomationProperties.LabeledBy="{Binding ElementName=MoveDownButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button x:Name="SaveAsBtn" Content="&#xE74E;" Style="{StaticResource ToolbarButtonAccent}" Click="SaveAs_Click" ToolTip="Save As"/>
-                    <Button Content="&#xE8B9;" Style="{StaticResource ToolbarButton}" Click="SaveFlattened_Click" ToolTip="Save Flattened PDF (rasterize all pages — fully uneditable)"/>
-                    <Button Content="&#xE749;" Style="{StaticResource ToolbarButton}" Click="Print_Click" ToolTip="Print (Ctrl+P)"/>
+                    <Button x:Name="SaveAsBtn" Content="&#xE74E;" Style="{StaticResource ToolbarButtonAccent}" Click="SaveAs_Click" ToolTip="Save As (Ctrl+S, Alt+S)" KeyboardNavigation.TabIndex="10" AutomationProperties.Name="Save as" AutomationProperties.HelpText="Save the PDF with annotations. Shortcut Ctrl+S. Access key Alt+S." AutomationProperties.AccessKey="S" AutomationProperties.LabeledBy="{Binding ElementName=SaveAsButtonLabel}"/>
+                    <Button Content="&#xE8B9;" Style="{StaticResource ToolbarButton}" Click="SaveFlattened_Click" ToolTip="Save Flattened PDF (Alt+F)" KeyboardNavigation.TabIndex="11" AutomationProperties.Name="Save flattened PDF" AutomationProperties.HelpText="Rasterize all pages and save a fully uneditable PDF. Access key Alt+F." AutomationProperties.AccessKey="F" AutomationProperties.LabeledBy="{Binding ElementName=SaveFlattenedButtonLabel}"/>
+                    <Button Content="&#xE749;" Style="{StaticResource ToolbarButton}" Click="Print_Click" ToolTip="Print (Ctrl+P, Alt+P)" KeyboardNavigation.TabIndex="12" AutomationProperties.Name="Print" AutomationProperties.HelpText="Print the current PDF. Shortcut Ctrl+P. Access key Alt+P." AutomationProperties.AccessKey="P" AutomationProperties.LabeledBy="{Binding ElementName=PrintButtonLabel}"/>
                 </StackPanel>
                 <!-- Edit tools + zoom -->
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button x:Name="ToolSelectBtn" Content="&#xE8B3;" Style="{StaticResource ToolbarButton}" Click="ToolSelect_Click" ToolTip="Select Tool - click annotations, drag to select text, double-click to edit"/>
-                    <Button x:Name="ToolTextBtn" Content="&#xE8D2;" Style="{StaticResource ToolbarButton}" Click="ToolText_Click" ToolTip="Text Tool - click to add text"/>
-                    <Button x:Name="ToolHighlightBtn" Content="&#xED56;" Style="{StaticResource ToolbarButton}" Click="ToolHighlight_Click" ToolTip="Highlight Tool - drag to highlight"/>
-                    <Button x:Name="ToolDrawBtn" Content="&#xED63;" Style="{StaticResource ToolbarButton}" Click="ToolDraw_Click" ToolTip="Draw Tool - freehand ink"/>
+                    <Button x:Name="ToolSelectBtn" Content="&#xE8B3;" Style="{StaticResource ToolbarButton}" Click="ToolSelect_Click" ToolTip="Select Tool (Alt+Q)" KeyboardNavigation.TabIndex="13" AutomationProperties.Name="Select tool" AutomationProperties.HelpText="Select annotations, drag to select text, or double-click text to edit. Access key Alt+Q." AutomationProperties.AccessKey="Q" AutomationProperties.LabeledBy="{Binding ElementName=SelectToolButtonLabel}"/>
+                    <Button x:Name="ToolTextBtn" Content="&#xE8D2;" Style="{StaticResource ToolbarButton}" Click="ToolText_Click" ToolTip="Text Tool (Alt+T)" KeyboardNavigation.TabIndex="14" AutomationProperties.Name="Text tool" AutomationProperties.HelpText="Click the page to add text. Access key Alt+T." AutomationProperties.AccessKey="T" AutomationProperties.LabeledBy="{Binding ElementName=TextToolButtonLabel}"/>
+                    <Button x:Name="ToolHighlightBtn" Content="&#xED56;" Style="{StaticResource ToolbarButton}" Click="ToolHighlight_Click" ToolTip="Highlight Tool (Alt+H)" KeyboardNavigation.TabIndex="15" AutomationProperties.Name="Highlight tool" AutomationProperties.HelpText="Drag on the page to add a highlight. Access key Alt+H." AutomationProperties.AccessKey="H" AutomationProperties.LabeledBy="{Binding ElementName=HighlightToolButtonLabel}"/>
+                    <Button x:Name="ToolDrawBtn" Content="&#xED63;" Style="{StaticResource ToolbarButton}" Click="ToolDraw_Click" ToolTip="Draw Tool (Alt+R)" KeyboardNavigation.TabIndex="16" AutomationProperties.Name="Draw tool" AutomationProperties.HelpText="Draw freehand ink on the page. Access key Alt+R." AutomationProperties.AccessKey="R" AutomationProperties.LabeledBy="{Binding ElementName=DrawToolButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button x:Name="ToolSignatureBtn" Content="&#xEE56;" Style="{StaticResource ToolbarButton}" Click="ToolSignature_Click" ToolTip="Signature - create and place signatures"/>
+                    <Button x:Name="ToolSignatureBtn" Content="&#xEE56;" Style="{StaticResource ToolbarButton}" Click="ToolSignature_Click" ToolTip="Signature (Alt+G)" KeyboardNavigation.TabIndex="17" AutomationProperties.Name="Signature tool" AutomationProperties.HelpText="Create and place signatures. Access key Alt+G." AutomationProperties.AccessKey="G" AutomationProperties.LabeledBy="{Binding ElementName=SignatureButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <Button Content="&#xE7A7;" Style="{StaticResource ToolbarButton}" Click="Undo_Click" ToolTip="Undo Last (Ctrl+Z)"/>
-                    <Button Content="&#xED62;" Style="{StaticResource ToolbarButtonDanger}" Click="ClearAnnotations_Click" ToolTip="Clear All Annotations"/>
+                    <Button Content="&#xE7A7;" Style="{StaticResource ToolbarButton}" Click="Undo_Click" ToolTip="Undo Last (Ctrl+Z, Alt+Z)" KeyboardNavigation.TabIndex="18" AutomationProperties.Name="Undo last annotation" AutomationProperties.HelpText="Undo the last annotation change. Shortcut Ctrl+Z. Access key Alt+Z." AutomationProperties.AccessKey="Z" AutomationProperties.LabeledBy="{Binding ElementName=UndoButtonLabel}"/>
+                    <Button Content="&#xED62;" Style="{StaticResource ToolbarButtonDanger}" Click="ClearAnnotations_Click" ToolTip="Clear All Annotations (Alt+L)" KeyboardNavigation.TabIndex="19" AutomationProperties.Name="Clear all annotations" AutomationProperties.HelpText="Clear all annotations on the current page. Access key Alt+L." AutomationProperties.AccessKey="L" AutomationProperties.LabeledBy="{Binding ElementName=ClearAnnotationsButtonLabel}"/>
                     <Rectangle Width="1" Fill="{StaticResource BorderDim}" Margin="4,6"/>
-                    <ComboBox x:Name="ZoomBox" Width="96" Height="24" VerticalAlignment="Center"
-                              Margin="0,0,4,0"
-                              IsEditable="True" IsReadOnly="True"
-                              Style="{StaticResource DarkComboBox}"
-                              SelectionChanged="ZoomBox_SelectionChanged" ToolTip="Zoom level (Ctrl+scroll to zoom)">
-                        <ComboBoxItem Tag="fitwidth">Fit Width</ComboBoxItem>
-                        <ComboBoxItem Tag="fitpage">Fit Page</ComboBoxItem>
-                        <ComboBoxItem Tag="0.5">50%</ComboBoxItem>
-                        <ComboBoxItem Tag="0.75">75%</ComboBoxItem>
-                        <ComboBoxItem Tag="1.0" IsSelected="True">100%</ComboBoxItem>
-                        <ComboBoxItem Tag="1.25">125%</ComboBoxItem>
-                        <ComboBoxItem Tag="1.5">150%</ComboBoxItem>
-                        <ComboBoxItem Tag="2.0">200%</ComboBoxItem>
+                    <ComboBox x:Name="ZoomBox" Width="96" Height="24" VerticalAlignment="Center" Margin="0,0,4,0" IsEditable="True" IsReadOnly="True" Style="{StaticResource DarkComboBox}" KeyboardNavigation.TabIndex="20" AutomationProperties.Name="Zoom level" AutomationProperties.HelpText="Choose the page zoom level. Use Control plus mouse wheel to zoom." AutomationProperties.LabeledBy="{Binding ElementName=ZoomLabel}" SelectionChanged="ZoomBox_SelectionChanged" ToolTip="Zoom level (Ctrl+scroll to zoom)">
+                        <ComboBoxItem Tag="fitwidth" AutomationProperties.Name="Fit width">Fit Width</ComboBoxItem>
+                        <ComboBoxItem Tag="fitpage" AutomationProperties.Name="Fit page">Fit Page</ComboBoxItem>
+                        <ComboBoxItem Tag="0.5" AutomationProperties.Name="50 percent">50%</ComboBoxItem>
+                        <ComboBoxItem Tag="0.75" AutomationProperties.Name="75 percent">75%</ComboBoxItem>
+                        <ComboBoxItem Tag="1.0" IsSelected="True" AutomationProperties.Name="100 percent">100%</ComboBoxItem>
+                        <ComboBoxItem Tag="1.25" AutomationProperties.Name="125 percent">125%</ComboBoxItem>
+                        <ComboBoxItem Tag="1.5" AutomationProperties.Name="150 percent">150%</ComboBoxItem>
+                        <ComboBoxItem Tag="2.0" AutomationProperties.Name="200 percent">200%</ComboBoxItem>
                     </ComboBox>
                 </StackPanel>
             </Grid>
         </Border>
 
         <!-- Main content -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="2" KeyboardNavigation.TabNavigation="Continue">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="180" MinWidth="140" MaxWidth="260"/>
                 <ColumnDefinition Width="*"/>
@@ -527,44 +586,29 @@
             <!-- Sidebar -->
             <Border Grid.Column="0" Background="#1e1e1e" BorderBrush="{StaticResource BorderDim}" BorderThickness="0,0,1,0">
                 <DockPanel>
-                    <TextBlock DockPanel.Dock="Top" Text="PAGES" Foreground="{StaticResource TextSecondary}"
-                               FontFamily="Segoe UI" FontSize="11" FontWeight="SemiBold" Padding="12,10"/>
-                    <ListBox x:Name="PageList" Style="{StaticResource PageListBox}"
-                             BorderThickness="0" SelectionMode="Extended"
-                             SelectionChanged="PageList_SelectionChanged"
-                             AllowDrop="True" Drop="PageList_Drop" DragOver="PageList_DragOver"
-                             PreviewMouseLeftButtonDown="PageList_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="PageList_PreviewMouseMove"/>
+                    <TextBlock x:Name="PagesHeader" DockPanel.Dock="Top" Text="PAGES" Foreground="{StaticResource TextSecondary}" FontFamily="Segoe UI" FontSize="11" FontWeight="SemiBold" Padding="12,10"/>
+                    <ListBox x:Name="PageList" Style="{StaticResource PageListBox}" BorderThickness="0" SelectionMode="Extended" KeyboardNavigation.TabIndex="30" AutomationProperties.Name="Pages" AutomationProperties.HelpText="List of pages in the current PDF. Select pages to preview, reorder, extract, or delete." AutomationProperties.LabeledBy="{Binding ElementName=PagesHeader}" SelectionChanged="PageList_SelectionChanged" AllowDrop="True" Drop="PageList_Drop" DragOver="PageList_DragOver" PreviewMouseLeftButtonDown="PageList_PreviewMouseLeftButtonDown" PreviewMouseMove="PageList_PreviewMouseMove"/>
                 </DockPanel>
             </Border>
 
             <!-- Preview area -->
             <Border Grid.Column="1" Background="{StaticResource BgDark}">
                 <Grid>
+                    <TextBlock x:Name="DropZoneLabel" Text="Open PDF drop zone" Width="0" Height="0" Opacity="0" IsHitTestVisible="False" Focusable="False"/>
+                    <TextBlock x:Name="PagePreviewLabel" Text="PDF page preview" Width="0" Height="0" Opacity="0" IsHitTestVisible="False" Focusable="False"/>
+                    <TextBlock x:Name="AnnotationCanvasLabel" Text="PDF annotation canvas" Width="0" Height="0" Opacity="0" IsHitTestVisible="False" Focusable="False"/>
                     <!-- Drop zone -->
-                    <Border x:Name="DropZone" Background="Transparent"
-                            AllowDrop="True" Drop="DropZone_Drop" DragOver="DropZone_DragOver"
-                            MouseLeftButtonDown="DropZone_Click">
-                        <Border BorderBrush="{StaticResource BorderDim}" BorderThickness="2"
-                                CornerRadius="8" Margin="40" Padding="40"
-                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                Background="Transparent" Style="{x:Null}">
+                    <Border x:Name="DropZone" Background="Transparent" Focusable="True" KeyboardNavigation.TabIndex="40" AutomationProperties.Name="Open PDF drop zone" AutomationProperties.HelpText="Drop a PDF file here, or press Enter or Space to browse for a PDF." AutomationProperties.LabeledBy="{Binding ElementName=DropZoneLabel}" AllowDrop="True" Drop="DropZone_Drop" DragOver="DropZone_DragOver" KeyDown="DropZone_KeyDown" MouseLeftButtonDown="DropZone_Click">
+                        <Border BorderBrush="{StaticResource BorderDim}" BorderThickness="2" CornerRadius="8" Margin="40" Padding="40" HorizontalAlignment="Center" VerticalAlignment="Center" Background="Transparent" Style="{x:Null}">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <TextBlock Text="Drop PDF here" FontFamily="Segoe UI" FontSize="20"
-                                           Foreground="{StaticResource TextSecondary}" HorizontalAlignment="Center"/>
-                                <TextBlock Text="or click to browse" FontFamily="Segoe UI" FontSize="13"
-                                           Foreground="{StaticResource BorderDim}" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                <TextBlock Text="Drop PDF here" FontFamily="Segoe UI" FontSize="20" Foreground="{StaticResource TextSecondary}" HorizontalAlignment="Center"/>
+                                <TextBlock Text="or click to browse" FontFamily="Segoe UI" FontSize="13" Foreground="{StaticResource BorderDim}" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                             </StackPanel>
                         </Border>
                     </Border>
 
                     <!-- PDF page with annotation overlay -->
-                    <ScrollViewer x:Name="PagePreviewPanel" Visibility="Collapsed"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  Background="Transparent"
-                                  PreviewMouseWheel="PagePreview_PreviewMouseWheel"
-                                  AllowDrop="True" Drop="DropZone_Drop" DragOver="DropZone_DragOver">
+                    <ScrollViewer x:Name="PagePreviewPanel" Visibility="Collapsed" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Transparent" Focusable="True" KeyboardNavigation.TabIndex="40" AutomationProperties.Name="PDF page preview" AutomationProperties.HelpText="Scrollable preview of the selected PDF page." AutomationProperties.LabeledBy="{Binding ElementName=PagePreviewLabel}" PreviewMouseWheel="PagePreview_PreviewMouseWheel" AllowDrop="True" Drop="DropZone_Drop" DragOver="DropZone_DragOver">
                         <Border HorizontalAlignment="Center" VerticalAlignment="Top" Padding="16">
                             <Grid x:Name="PageContentGrid">
                                 <Grid.LayoutTransform>
@@ -572,11 +616,8 @@
                                 </Grid.LayoutTransform>
                                 <Border Background="White">
                                     <Grid>
-                                        <Image x:Name="PageImage" RenderOptions.BitmapScalingMode="HighQuality" Stretch="None"/>
-                                        <Canvas x:Name="AnnotationCanvas" Background="Transparent" ClipToBounds="True"
-                                                PreviewMouseLeftButtonDown="Canvas_MouseLeftButtonDown"
-                                                MouseMove="Canvas_MouseMove"
-                                                PreviewMouseLeftButtonUp="Canvas_MouseLeftButtonUp"/>
+                                        <Image x:Name="PageImage" RenderOptions.BitmapScalingMode="HighQuality" Stretch="None" AutomationProperties.Name="Rendered PDF page"/>
+                                        <Canvas x:Name="AnnotationCanvas" Background="Transparent" ClipToBounds="True" Focusable="True" KeyboardNavigation.TabIndex="41" AutomationProperties.Name="PDF annotation canvas" AutomationProperties.HelpText="Use the selected tool to add, select, edit, or delete annotations on the current page." AutomationProperties.LabeledBy="{Binding ElementName=AnnotationCanvasLabel}" PreviewMouseLeftButtonDown="Canvas_MouseLeftButtonDown" MouseMove="Canvas_MouseMove" PreviewMouseLeftButtonUp="Canvas_MouseLeftButtonUp"/>
                                     </Grid>
                                 </Border>
                             </Grid>
@@ -588,20 +629,13 @@
 
         <!-- Status bar -->
         <Border Grid.Row="3" Background="#111111" BorderBrush="{StaticResource BorderDim}" BorderThickness="0,1,0,0">
-            <Grid Margin="16,0">
-                <TextBlock x:Name="StatusText" Text="Ready"
-                           Foreground="{StaticResource TextSecondary}"
-                           FontFamily="Segoe UI" FontSize="11" VerticalAlignment="Center"/>
+            <Grid Margin="16,0" KeyboardNavigation.TabNavigation="Continue">
+                <TextBlock x:Name="StatusText" Text="Ready" Foreground="{StaticResource TextSecondary}" FontFamily="Segoe UI" FontSize="11" VerticalAlignment="Center" AutomationProperties.Name="Status" AutomationProperties.HelpText="Current application status" AutomationProperties.LiveSetting="Polite"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                    <TextBlock x:Name="VersionLabel" Text="v1.2.1"
-                               Foreground="#444444" FontFamily="Consolas"
-                               FontSize="10" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                    <TextBlock FontSize="10" VerticalAlignment="Center"
-                               FontFamily="Consolas">
+                    <TextBlock x:Name="VersionLabel" Text="v1.2.1" Foreground="#444444" FontFamily="Consolas" FontSize="10" VerticalAlignment="Center" Margin="0,0,12,0" AutomationProperties.Name="Application version"/>
+                    <TextBlock FontSize="10" VerticalAlignment="Center" FontFamily="Consolas">
                         <Run Text="&#x00A9; 2026 " Foreground="#444444"/>
-                        <Hyperlink NavigateUri="https://thekiller.net"
-                                   RequestNavigate="Hyperlink_RequestNavigate"
-                                   Foreground="#444444" TextDecorations="None">
+                        <Hyperlink NavigateUri="https://thekiller.net" RequestNavigate="Hyperlink_RequestNavigate" KeyboardNavigation.TabIndex="50" AutomationProperties.Name="Steve the Killer website" AutomationProperties.HelpText="Opens the Steve the Killer website" Foreground="#444444" TextDecorations="None">
                             <Run Text="Steve the Killer"/>
                         </Hyperlink>
                     </TextBlock>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -116,6 +117,41 @@ namespace KillerPDF
                 if (args.Length > 1 && System.IO.File.Exists(args[1]))
                     OpenFile(args[1]);
             };
+        }
+
+        private bool ShouldIgnoreGlobalShortcut() => _activeTextBox is not null && _activeTextBox.IsFocused;
+
+        private void OpenCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (ShouldIgnoreGlobalShortcut()) return;
+            Open_Click(sender, e);
+        }
+
+        private void SaveCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (ShouldIgnoreGlobalShortcut()) return;
+            SaveAs_Click(sender, e);
+        }
+
+        private void PrintCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (ShouldIgnoreGlobalShortcut()) return;
+            Print_Click(sender, e);
+        }
+
+        private void FindCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (ShouldIgnoreGlobalShortcut()) return;
+            ToggleSearchBar();
+        }
+
+        private void DropZone_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter || e.Key == Key.Space)
+            {
+                Open_Click(sender, e);
+                e.Handled = true;
+            }
         }
 
         // ============================================================
@@ -250,27 +286,30 @@ namespace KillerPDF
         {
             var menu = new ContextMenu();
 
-            menu.Items.Add(MakeMenuItem("Copy Text", (s, e) => CopySelectedText(), "Ctrl+C"));
-            menu.Items.Add(MakeMenuItem("Print", (s, e) => Print_Click(s!, e), "Ctrl+P"));
+            menu.Items.Add(MakeMenuItem("_Copy Text", (s, e) => CopySelectedText(), "Ctrl+C", "Copy selected text to the clipboard"));
+            menu.Items.Add(MakeMenuItem("_Print", (s, e) => Print_Click(s!, e), "Ctrl+P", "Print the current PDF"));
             menu.Items.Add(new Separator());
-            menu.Items.Add(MakeMenuItem("Select Tool", (s, e) => SetTool(EditTool.Select)));
-            menu.Items.Add(MakeMenuItem("Text Tool", (s, e) => SetTool(EditTool.Text)));
-            menu.Items.Add(MakeMenuItem("Highlight Tool", (s, e) => SetTool(EditTool.Highlight)));
-            menu.Items.Add(MakeMenuItem("Draw Tool", (s, e) => SetTool(EditTool.Draw)));
+            menu.Items.Add(MakeMenuItem("_Select Tool", (s, e) => SetTool(EditTool.Select), null, "Switch to the select tool"));
+            menu.Items.Add(MakeMenuItem("_Text Tool", (s, e) => SetTool(EditTool.Text), null, "Switch to the text tool"));
+            menu.Items.Add(MakeMenuItem("_Highlight Tool", (s, e) => SetTool(EditTool.Highlight), null, "Switch to the highlight tool"));
+            menu.Items.Add(MakeMenuItem("_Draw Tool", (s, e) => SetTool(EditTool.Draw), null, "Switch to the draw tool"));
             menu.Items.Add(new Separator());
-            menu.Items.Add(MakeMenuItem("Delete Selected", (s, e) => DeleteSelected(), "Delete"));
-            menu.Items.Add(MakeMenuItem("Undo Last", (s, e) => Undo_Click(s!, e), "Ctrl+Z"));
-            menu.Items.Add(MakeMenuItem("Clear Page Annotations", (s, e) => ClearAnnotations_Click(s!, e)));
+            menu.Items.Add(MakeMenuItem("De_lete Selected", (s, e) => DeleteSelected(), "Delete", "Delete the selected annotation"));
+            menu.Items.Add(MakeMenuItem("_Undo Last", (s, e) => Undo_Click(s!, e), "Ctrl+Z", "Undo the last annotation change"));
+            menu.Items.Add(MakeMenuItem("Cle_ar Page Annotations", (s, e) => ClearAnnotations_Click(s!, e), null, "Clear all annotations on this page"));
 
             _annotationCanvas.ContextMenu = menu;
         }
 
-        private static MenuItem MakeMenuItem(string header, RoutedEventHandler click, string? gesture = null)
+        private static MenuItem MakeMenuItem(string header, RoutedEventHandler click, string? gesture = null, string? helpText = null)
         {
             var item = new MenuItem { Header = header };
             item.Click += click;
             if (gesture != null)
                 item.InputGestureText = gesture;
+            var automationName = header.Replace("_", string.Empty);
+            AutomationProperties.SetName(item, automationName);
+            AutomationProperties.SetHelpText(item, helpText ?? automationName);
             return item;
         }
 
@@ -1818,6 +1857,8 @@ namespace KillerPDF
                     Padding = new Thickness(6, 2, 6, 2),
                     VerticalContentAlignment = VerticalAlignment.Center
                 };
+                AutomationProperties.SetName(_searchBox, "Search text");
+                AutomationProperties.SetHelpText(_searchBox, "Enter text to find in the current PDF. Press Enter for next result and Shift Enter for previous result.");
                 _searchBox.KeyDown += SearchBox_KeyDown;
                 _searchBox.TextChanged += SearchBox_TextChanged;
 
@@ -1829,6 +1870,9 @@ namespace KillerPDF
                     VerticalAlignment = VerticalAlignment.Center,
                     Margin = new Thickness(8, 0, 0, 0)
                 };
+                AutomationProperties.SetName(_searchStatus, "Search status");
+                AutomationProperties.SetHelpText(_searchStatus, "Search result status");
+                AutomationProperties.SetLiveSetting(_searchStatus, AutomationLiveSetting.Polite);
 
                 var closeBtn = new Button
                 {
@@ -1837,6 +1881,8 @@ namespace KillerPDF
                     Style = (Style)FindResource("ToolbarButton"),
                     ToolTip = "Close search (Esc)"
                 };
+                AutomationProperties.SetName(closeBtn, "Close search");
+                AutomationProperties.SetHelpText(closeBtn, "Close the search bar. Shortcut Escape.");
                 closeBtn.Click += (s, e) => CloseSearchBar();
 
                 var searchIcon = new TextBlock
@@ -2382,6 +2428,8 @@ namespace KillerPDF
                 AcceptsReturn = true,
                 Tag = pageIdx
             };
+            AutomationProperties.SetName(tb, "Annotation text");
+            AutomationProperties.SetHelpText(tb, "Type annotation text. Press Enter to save or Escape to cancel.");
             Canvas.SetLeft(tb, pos.X);
             Canvas.SetTop(tb, pos.Y);
             _annotationCanvas.Children.Add(tb);
@@ -2468,6 +2516,34 @@ namespace KillerPDF
             // Don't intercept keys when typing in a TextBox
             if (_activeTextBox is not null && _activeTextBox.IsFocused) return;
 
+            if (Keyboard.Modifiers == ModifierKeys.Alt)
+            {
+                var accessKey = e.SystemKey != Key.None ? e.SystemKey : e.Key;
+                switch (accessKey)
+                {
+                    case Key.O: Open_Click(this, e); break;
+                    case Key.W: CloseFile(); break;
+                    case Key.M: Merge_Click(this, e); break;
+                    case Key.E: Split_Click(this, e); break;
+                    case Key.D: Delete_Click(this, e); break;
+                    case Key.U: MoveUp_Click(this, e); break;
+                    case Key.N: MoveDown_Click(this, e); break;
+                    case Key.S: SaveAs_Click(this, e); break;
+                    case Key.F: SaveFlattened_Click(this, e); break;
+                    case Key.P: Print_Click(this, e); break;
+                    case Key.Q: SetTool(EditTool.Select); break;
+                    case Key.T: SetTool(EditTool.Text); break;
+                    case Key.H: SetTool(EditTool.Highlight); break;
+                    case Key.R: SetTool(EditTool.Draw); break;
+                    case Key.G: ToolSignature_Click(this, e); break;
+                    case Key.Z: Undo_Click(this, e); break;
+                    case Key.L: ClearAnnotations_Click(this, e); break;
+                    default: return;
+                }
+                e.Handled = true;
+                return;
+            }
+
             if (e.Key == Key.C && Keyboard.Modifiers == ModifierKeys.Control)
             {
                 CopySelectedText();
@@ -2478,19 +2554,9 @@ namespace KillerPDF
                 SelectAllText();
                 e.Handled = true;
             }
-            else if (e.Key == Key.F && Keyboard.Modifiers == ModifierKeys.Control)
-            {
-                ToggleSearchBar();
-                e.Handled = true;
-            }
             else if (e.Key == Key.Escape && _searchBar is not null && _searchBar.Visibility == Visibility.Visible)
             {
                 CloseSearchBar();
-                e.Handled = true;
-            }
-            else if (e.Key == Key.P && Keyboard.Modifiers == ModifierKeys.Control)
-            {
-                Print_Click(this, e);
                 e.Handled = true;
             }
             else if (e.Key == Key.Delete && _selectedAnnotation is not null)
@@ -2506,11 +2572,6 @@ namespace KillerPDF
             else if (e.Key == Key.W && Keyboard.Modifiers == ModifierKeys.Control)
             {
                 CloseFile();
-                e.Handled = true;
-            }
-            else if (e.Key == Key.O && Keyboard.Modifiers == ModifierKeys.Control)
-            {
-                Open_Click(this, e);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
Refs #23

## Summary
- Added UI Automation names, help text, labels, live status announcements, and focus visuals across MainWindow controls.
- Wired Ctrl+O/Ctrl+S/Ctrl+P/Ctrl+F through WPF InputBindings/CommandBindings and added unique Alt access keys for major toolbar actions.
- Improved logical tab order through chrome/toolbar, page sidebar, page canvas/drop zone, and status link.
- Switched selection/focus information colors to SystemColors dynamic resources for high-contrast visibility.

## Deferred items
- Broader refactoring of the MainWindow.xaml.cs god-class is intentionally deferred.
- Full assistive-technology verification should be performed on Windows with Narrator/Inspect.

## Validation
- XAML parsed as well-formed XML locally.
- git diff --check passed.
- Ran code-review agent through 5 passes and addressed findings.
- Not built on Windows here; this macOS environment lacks dotnet and the project is net48 WPF Windows-only.