### PR TITLE
ci: add Windows build workflow (windows-latest, net48)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,19 @@ name: build
 # windows-latest does.
 #
 # Migration plan: once #43 (modernize to net9.0-windows) merges, swap
-#   runs-on: windows-latest
-# to
-#   runs-on: tdp-extend
-# and replace the publish step's `-r win-x64` is fine to keep. The
-# tdp-extend Linux ARC runner has the .NET 9 SDK preinstalled and can build
-# net9.0-windows projects with EnableWindowsTargeting (see comment below).
+# this job to:
+#
+#   jobs:
+#     build-wpf:
+#       runs-on: tdp-extend
+#       steps:
+#         - uses: actions/checkout@v4
+#         - run: dotnet build KillerPDF.csproj -c Release -p:EnableWindowsTargeting=true
+#
+# The tdp-extend Linux ARC scaleset has the .NET 9 SDK preinstalled and
+# builds net9.0-windows projects via EnableWindowsTargeting=true. Until
+# #43 lands, net48 needs the Windows-only msbuild/Reference Assemblies
+# stack which only windows-latest provides.
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: build
+
+# CI for KillerPDF.
+#
+# Current state (pre-#43): project targets net48 + WPF + native pdfium.dll.
+# `dotnet build` and `dotnet publish` both work for SDK-style net48 on a
+# Windows host that has the .NET Framework 4.8 dev pack preinstalled — which
+# windows-latest does.
+#
+# Migration plan: once #43 (modernize to net9.0-windows) merges, swap
+#   runs-on: windows-latest
+# to
+#   runs-on: tdp-extend
+# and replace the publish step's `-r win-x64` is fine to keep. The
+# tdp-extend Linux ARC runner has the .NET 9 SDK preinstalled and can build
+# net9.0-windows projects with EnableWindowsTargeting (see comment below).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (windows-latest, net48)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # NuGet package cache. SDK-style restore writes to %UserProfile%\.nuget\packages.
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: dotnet --info
+        run: dotnet --info
+
+      - name: Restore
+        run: dotnet restore KillerPDF.csproj
+
+      - name: Build (Release, x64)
+        run: dotnet build KillerPDF.csproj -c Release -p:Platform=x64 --no-restore
+
+      - name: Publish (Release, x64)
+        run: dotnet publish KillerPDF.csproj -c Release -p:Platform=x64 --no-build -o publish
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: KillerPDF-${{ github.sha }}
+          path: publish/
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Adds `.github/workflows/build.yml`. Builds + publishes KillerPDF on `windows-latest` (which has the .NET Framework 4.8 dev pack and .NET SDK preinstalled — handles the SDK-style net48 csproj fine).

## What it does
- `actions/checkout@v4` → `actions/cache@v4` (NuGet) → `dotnet restore` → `dotnet build -c Release -p:Platform=x64` → `dotnet publish -c Release -p:Platform=x64 -o publish` → upload `publish/` as artifact.
- Triggers: push to main, PRs targeting main, manual dispatch.
- Concurrency: cancels in-progress builds for the same ref.

## Migration plan
After PR #43 (modernize to `net9.0-windows`) merges, swap:

```yaml
runs-on: windows-latest
```

to:

```yaml
runs-on: tdp-extend
```

The org's Linux ARC scaleset has .NET 9 SDK preinstalled and can build `net9.0-windows` projects via SDK's cross-platform Windows targeting. No other workflow changes required at that point — `dotnet restore/build/publish` commands are identical.

Refs: KillerPDF CI bootstrap. Companion to #43 modernization.