### PR TITLE
Print dialog & toolbar UX: right-click split buttons, numeric steppers, remembered settings

### DIFF
--- a/FileOperations.cs
+++ b/FileOperations.cs
@@ -796,6 +796,7 @@ namespace KillerPDF
         // Dropdown next to the Open button: the recent-files list.
         private void OpenRecent_Click(object sender, RoutedEventArgs e)
         {
+            e.Handled = true;   // also fired by right-click on the Open button; don't let it bubble
             var menu = new ContextMenu();
             TextOptions.SetTextFormattingMode(menu, TextFormattingMode.Display);
             TextOptions.SetTextRenderingMode(menu, TextRenderingMode.Grayscale);
@@ -1076,6 +1077,7 @@ namespace KillerPDF
         // Dropdown next to the Save button: explicit Save / Save As.
         private void SaveMenu_Click(object sender, RoutedEventArgs e)
         {
+            e.Handled = true;   // also fired by right-click on the Save button; don't let it bubble
             var menu = new ContextMenu();
             TextOptions.SetTextFormattingMode(menu, TextFormattingMode.Display);
             TextOptions.SetTextRenderingMode(menu, TextRenderingMode.Grayscale);

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1089,11 +1089,11 @@
                     <!-- File: New / Open / Close / Save / Print -->
                     <Button Content="&#xE7C3;" Style="{StaticResource ToolbarButton}" Click="New_Click" ToolTip="{DynamicResource Str_TT_NewBlank}"/>
                     <Button x:Name="CloseFileBtn" Content="&#xE711;" Style="{StaticResource ToolbarButton}" Click="CloseFile_Click" ToolTip="{DynamicResource Str_TT_CloseFile}" IsEnabled="False"/>
-                    <Button x:Name="OpenFileBtn" Content="&#xE8DA;" Style="{StaticResource ToolbarSplitMain}" Click="Open_Click" ToolTip="{DynamicResource Str_TT_Open}"/>
+                    <Button x:Name="OpenFileBtn" Content="&#xE8DA;" Style="{StaticResource ToolbarSplitMain}" Click="Open_Click" MouseRightButtonUp="OpenRecent_Click" ToolTip="{DynamicResource Str_TT_Open}"/>
                     <Button x:Name="OpenRecentBtn" Content="&#xF08E;" FontSize="10" Width="13" Padding="0" Margin="-6,0,0,0" Style="{StaticResource ToolbarButton}" Click="OpenRecent_Click" ToolTip="Recent files"/>
-                    <Button x:Name="SaveAsBtn" Content="&#xE74E;" Style="{StaticResource ToolbarSplitMainAccent}" Click="Save_Click" ToolTip="{DynamicResource Str_TT_Save}"/>
+                    <Button x:Name="SaveAsBtn" Content="&#xE74E;" Style="{StaticResource ToolbarSplitMainAccent}" Click="Save_Click" MouseRightButtonUp="SaveMenu_Click" ToolTip="{DynamicResource Str_TT_Save}"/>
                     <Button x:Name="SaveMenuBtn" Content="&#xF08E;" FontSize="10" Width="13" Padding="0" Margin="-6,0,0,0" Style="{StaticResource ToolbarButton}" Click="SaveMenu_Click" ToolTip="Save options"/>
-                    <Button x:Name="OcrBtn" Content="&#xEE6F;" Style="{StaticResource ToolbarSplitMain}" Click="Ocr_Click" ToolTip="{DynamicResource Str_TT_Ocr}"/>
+                    <Button x:Name="OcrBtn" Content="&#xEE6F;" Style="{StaticResource ToolbarSplitMain}" Click="Ocr_Click" MouseRightButtonUp="OcrMenu_Click" ToolTip="{DynamicResource Str_TT_Ocr}"/>
                     <Button x:Name="OcrMenuBtn" Content="&#xF08E;" FontSize="10" Width="13" Padding="0" Margin="-6,0,0,0" Style="{StaticResource ToolbarButton}" Click="OcrMenu_Click" ToolTip="OCR options"/>
                     <Button Content="&#xE8B9;" Style="{StaticResource ToolbarButton}" Click="SaveFlattened_Click" ToolTip="{DynamicResource Str_TT_SaveFlattened}"/>
                     <Button Content="&#xE749;" Style="{StaticResource ToolbarButton}" Click="Print_Click" ToolTip="{DynamicResource Str_TT_Print}"/>

--- a/Ocr.cs
+++ b/Ocr.cs
@@ -563,6 +563,7 @@ namespace KillerPDF
         // the remaining entries are stubs until their commands land (Region, Searchable PDF, Extract Text).
         private void OcrMenu_Click(object sender, RoutedEventArgs e)
         {
+            e.Handled = true;   // also fired by right-click on the OCR button; don't let it bubble
             var menu = MakeThemedMenu();
             if (_doc is null)
             {

--- a/PrintPreviewWindow.cs
+++ b/PrintPreviewWindow.cs
@@ -153,6 +153,63 @@ namespace KillerPDF
             tb.Template            = MakeTextBoxTemplate();
         }
 
+        // Wires a TextBox as a positive-integer field: digits only, clamped to [min,max], steppable with
+        // the Up/Down arrow keys and the mouse wheel. Returns get/set so a spinner can drive the same value.
+        private static (Func<int> Get, Action<int> Set) NumericField(TextBox box, int min, int max)
+        {
+            int Get() => int.TryParse(box.Text?.Trim(), out int n) ? Math.Min(Math.Max(n, min), max) : min;
+            void Set(int n)
+            {
+                n = Math.Min(Math.Max(n, min), max);
+                box.Text = n.ToString();
+                box.CaretIndex = box.Text.Length;
+            }
+            box.PreviewTextInput += (_, ev) => ev.Handled = !ev.Text.All(char.IsDigit);
+            DataObject.AddPastingHandler(box, (_, ev) =>
+            {
+                if (ev.DataObject.GetData(typeof(string)) is string s && !s.All(char.IsDigit))
+                    ev.CancelCommand();
+            });
+            box.PreviewKeyDown += (_, ev) =>
+            {
+                if (ev.Key == Key.Up)   { Set(Get() + 1); ev.Handled = true; }
+                if (ev.Key == Key.Down) { Set(Get() - 1); ev.Handled = true; }
+            };
+            box.PreviewMouseWheel += (_, ev) => { Set(Get() + (ev.Delta > 0 ? 1 : -1)); ev.Handled = true; };
+            box.LostFocus += (_, _) => Set(Get());
+            return (Get, Set);
+        }
+
+        // Two stacked ▲/▼ stepper buttons (each half the field height) bound to the given get/set, sized to
+        // sit flush against the right edge of a field inside a DockPanel/StackPanel row.
+        private static Grid BuildStepper(Func<int> get, Action<int> set)
+        {
+            var g = new Grid { Width = 18, Margin = new Thickness(-1, 0, 0, 0) };
+            g.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            g.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            System.Windows.Controls.Primitives.RepeatButton Step(string glyph, int delta, int row)
+            {
+                var b = new System.Windows.Controls.Primitives.RepeatButton
+                {
+                    Content         = glyph,
+                    Padding         = new Thickness(0),
+                    FontSize        = 7,
+                    Foreground      = R("TextPrimary"),
+                    Background      = R("BgCanvas"),
+                    BorderBrush     = R("BorderDim"),
+                    BorderThickness = new Thickness(1),
+                    Cursor          = Cursors.Hand,
+                    Focusable       = false
+                };
+                b.Click += (_, _) => set(get() + delta);
+                Grid.SetRow(b, row);
+                return b;
+            }
+            g.Children.Add(Step("▲", +1, 0));
+            g.Children.Add(Step("▼", -1, 1));
+            return g;
+        }
+
 
         private static ControlTemplate MakeTextBoxTemplate()
         {
@@ -387,7 +444,8 @@ namespace KillerPDF
             ApplyComboStyle(orient);
             orient.Items.Add(S("Str_Print_Portrait"));
             orient.Items.Add(S("Str_Print_Landscape"));
-            orient.SelectedIndex = 0;
+            _landscape = App.GetSetting("PrintLandscape") == "1";   // restore last orientation
+            orient.SelectedIndex = _landscape ? 1 : 0;
             orient.SelectionChanged += (s, _) =>
             {
                 _landscape = ((ComboBox)s).SelectedIndex == 1;
@@ -403,7 +461,8 @@ namespace KillerPDF
             ApplyComboStyle(colorMode);
             colorMode.Items.Add(S("Str_Print_Color"));
             colorMode.Items.Add(S("Str_Print_BW"));
-            colorMode.SelectedIndex = 0;
+            _grayscale = App.GetSetting("PrintGrayscale") == "1";   // restore last colour choice
+            colorMode.SelectedIndex = _grayscale ? 1 : 0;
             colorMode.SelectionChanged += (s, _) => _grayscale = ((ComboBox)s).SelectedIndex == 1;
             panel.Children.Add(colorMode);
 
@@ -480,36 +539,44 @@ namespace KillerPDF
             _scaleBox = new TextBox
             {
                 Text         = "100",
-                Width        = 56,
                 Background    = R("BgCanvas"),
                 Foreground    = R("TextPrimary"),
                 BorderBrush   = R("BorderDim"),
                 Padding       = new Thickness(6, 4, 6, 4),
+                VerticalContentAlignment = VerticalAlignment.Center,
                 ToolTip       = S("Str_Print_ScaleHint")
             };
+            StyleTextBox(_scaleBox);
+            // Same numeric treatment as Copies: digits only, 1-1000 %, arrow-key / wheel / spinner stepping.
+            var (getScale, setScale) = NumericField(_scaleBox, 1, 1000);
             _scaleBox.TextChanged += (s, _) =>
             {
-                var t = ((TextBox)s).Text?.Trim().TrimEnd('%', ' ');
-                if (double.TryParse(t, out double p) && p > 0)
+                if (int.TryParse(((TextBox)s).Text?.Trim(), out int p) && p > 0)
                 {
                     _customPct = p;
                     if (_scaleMode == 2) UpdatePreview();
                 }
             };
-            StyleTextBox(_scaleBox);
 
-            var scaleRow = new StackPanel
+            // Full-width row matching the Copies field: the box fills the column, with the stepper and the
+            // "%" suffix docked at the right edge.
+            var scaleRow = new DockPanel
             {
-                Orientation = Orientation.Horizontal,
-                Margin      = new Thickness(0, 0, 0, 12),
-                Visibility  = Visibility.Collapsed
+                Margin        = new Thickness(0, 0, 0, 12),
+                LastChildFill = true,
+                Visibility    = Visibility.Collapsed
             };
-            scaleRow.Children.Add(_scaleBox);
-            scaleRow.Children.Add(new TextBlock
+            var scalePct = new TextBlock
             {
                 Text = "%", Foreground = R("TextSecondary"),
                 VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(6, 0, 0, 0)
-            });
+            };
+            DockPanel.SetDock(scalePct, Dock.Right);
+            var scaleSpin = BuildStepper(getScale, setScale);
+            DockPanel.SetDock(scaleSpin, Dock.Right);
+            scaleRow.Children.Add(scalePct);    // rightmost
+            scaleRow.Children.Add(scaleSpin);   // left of %
+            scaleRow.Children.Add(_scaleBox);   // fills the rest of the column width
             var scaleSlide = new TranslateTransform();
             scaleRow.RenderTransform = scaleSlide;
 
@@ -542,14 +609,24 @@ namespace KillerPDF
             _copiesBox = new TextBox
             {
                 Text        = "1",
-                Margin      = new Thickness(0, 4, 0, 12),
                 Background   = R("BgCanvas"),
                 Foreground   = R("TextPrimary"),
                 BorderBrush  = R("BorderDim"),
-                Padding      = new Thickness(6, 4, 6, 4)
+                Padding      = new Thickness(6, 4, 6, 4),
+                VerticalContentAlignment = VerticalAlignment.Center
             };
             StyleTextBox(_copiesBox);
-            panel.Children.Add(_copiesBox);
+            // Copies is replicated `copies` times in DoPrint, so 1 means exactly one printout; min 1.
+            var (getCopies, setCopies) = NumericField(_copiesBox, 1, 9999);
+
+            // Stepper flush against the right edge of the full-width field, so the row lines up with the
+            // Printer / Pages fields above and below it.
+            var copiesSpin = BuildStepper(getCopies, setCopies);
+            var copiesRow = new DockPanel { Margin = new Thickness(0, 4, 0, 12), LastChildFill = true };
+            DockPanel.SetDock(copiesSpin, Dock.Right);
+            copiesRow.Children.Add(copiesSpin);   // docked right, full field height
+            copiesRow.Children.Add(_copiesBox);   // fills the rest of the column width
+            panel.Children.Add(copiesRow);
 
             panel.Children.Add(Label(S("Str_Print_Pages")));
             _pagesBox = new TextBox
@@ -577,6 +654,7 @@ namespace KillerPDF
             _duplexCheck.Margin = new Thickness(0, 2, 0, 14);
             _duplexCheck.Checked   += (_, _) => _duplex = true;
             _duplexCheck.Unchecked += (_, _) => _duplex = false;
+            _duplexCheck.IsChecked = App.GetSetting("PrintDuplex") == "1";   // restore; cleared below if unsupported
             panel.Children.Add(_duplexCheck);
             UpdateDuplexAvailability();
 
@@ -710,7 +788,9 @@ namespace KillerPDF
 
             foreach (var q in _queues) _printerCombo.Items.Add(q.FullName);
 
-            int sel = def != null ? _queues.FindIndex(q => q.FullName == def.FullName) : 0;
+            string? savedPrinter = App.GetSetting("PrintPrinter");
+            int sel = !string.IsNullOrEmpty(savedPrinter) ? _queues.FindIndex(q => q.FullName == savedPrinter) : -1;
+            if (sel < 0) sel = def != null ? _queues.FindIndex(q => q.FullName == def.FullName) : 0;
             if (_queues.Count > 0)
             {
                 _printerCombo.SelectedIndex = sel >= 0 ? sel : 0;
@@ -862,6 +942,19 @@ namespace KillerPDF
             return sp;
         }
 
+        // Persists the device-level print choices so the dialog reopens with the user's last setup.
+        private void SavePrintPrefs()
+        {
+            try
+            {
+                if (_queue != null) App.SetSetting("PrintPrinter", _queue.FullName);
+                App.SetSetting("PrintLandscape", _landscape ? "1" : "0");
+                App.SetSetting("PrintGrayscale", _grayscale ? "1" : "0");
+                App.SetSetting("PrintDuplex",    _duplex     ? "1" : "0");
+            }
+            catch { /* settings are best-effort */ }
+        }
+
         private void DoPrint()
         {
             if (_queue == null)
@@ -881,6 +974,8 @@ namespace KillerPDF
 
             int.TryParse(_copiesBox.Text?.Trim(), out int copies);
             if (copies < 1) copies = 1;
+
+            SavePrintPrefs();   // remember printer / orientation / colour / two-sided for next time
 
             try
             {


### PR DESCRIPTION
Small UX improvements to the print dialog and toolbar (all opt-in, no behaviour change for existing flows):

- **Right-click split buttons** - right-clicking the Open, Save and OCR toolbar buttons opens the same dropdown as their little caret button. The menu handlers already anchor to the sender; they now mark the event handled so the right-click doesn't bubble.
- **Numeric steppers** - the Copies and custom Scale fields share one helper: digits only, clamped to a sensible range, and steppable via the Up/Down keys, the mouse wheel, or a small up/down spinner. Both fill the column width with the spinner flush at the right edge.
- **Remembered settings** - the print dialog now restores the last printer, orientation, colour and two-sided choice across sessions. Per-job values (copies / pages / scale) are intentionally not persisted.

Independent of the copies fix in #107 and the glyph fix in #108. Touches the same toolbar block as #108, so whichever merges second needs a trivial rebase.