### PR TITLE
Add Enter/Esc keyboard handling across dialogs

### DIFF
--- a/ColorPickerDialog.cs
+++ b/ColorPickerDialog.cs
@@ -168,8 +168,8 @@ namespace KillerPDF
             RebuildSavedRow();
             // OK / Cancel
             var btnRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 14, 0, 0) };
-            var cancel = MakeButton("Cancel", false); cancel.Click += (_, _) => { DialogResult = false; Close(); };
-            var ok = MakeButton("OK", true); ok.Margin = new Thickness(8, 0, 0, 0); ok.Click += (_, _) => Accept();
+            var cancel = MakeButton("Cancel", false); cancel.Click += (_, _) => { DialogResult = false; Close(); }; cancel.IsCancel = true;
+            var ok = MakeButton("OK", true); ok.Margin = new Thickness(8, 0, 0, 0); ok.Click += (_, _) => Accept(); ok.IsDefault = true;
             btnRow.Children.Add(cancel); btnRow.Children.Add(ok);
             panel.Children.Add(btnRow);
         }

--- a/DocumentInfoDialog.cs
+++ b/DocumentInfoDialog.cs
@@ -48,8 +48,10 @@ namespace KillerPDF
 
             var cancel = UiKit.Make(L("Str_DocInfo_Cancel"), accent: false);
             cancel.Click += (_, _2) => { DialogResult = false; Close(); };
+            cancel.IsCancel = true;   // Esc
             var save = UiKit.Make(L("Str_DocInfo_Save"), accent: true);
             save.Click += (_, _2) => SaveAndClose();
+            save.IsDefault = true;    // Enter
             var row = UiKit.ButtonRow(cancel, save);
             row.Margin = new Thickness(0, 16, 0, 0);
             body.Children.Add(row);

--- a/KillerDialog.cs
+++ b/KillerDialog.cs
@@ -125,6 +125,8 @@ namespace KillerPDF
                 // Shared themed button (UiKit.Make) so this dialog matches the print dialog et al.
                 var btn = UiKit.Make(label, accent);
                 btn.Margin = new Thickness(8, 0, 0, 0);
+                btn.IsDefault = accent;                           // Enter triggers the primary action
+                btn.IsCancel  = res == MessageBoxResult.Cancel;   // Esc triggers Cancel where there is one
                 btn.Click += (_, _2) => { result = res; win.Close(); };
                 return btn;
             }

--- a/PrintPreviewWindow.cs
+++ b/PrintPreviewWindow.cs
@@ -583,8 +583,10 @@ namespace KillerPDF
             var btnRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
             var cancel = MakeButton(S("Str_Stamp_Cancel"), false);
             cancel.Click += (_, _) => { DialogResult = false; Close(); };
+            cancel.IsCancel = true;          // Esc cancels the dialog
             var print = MakeButton(S("Str_Ctx_Print"), true);
             print.Click += (_, _) => DoPrint();
+            print.IsDefault = true;          // Enter prints
             print.IsEnabled = !_isLoading;   // enabled once all pages have rendered
             _printBtn = print;
             cancel.Margin = new Thickness(8, 0, 0, 0);   // gap; Cancel sits to the right of Print

--- a/SignDocumentDialog.cs
+++ b/SignDocumentDialog.cs
@@ -138,9 +138,11 @@ namespace KillerPDF
             var btnRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 16, 0, 0) };
             var sign = MakeButton(L("Str_Sign_Sign"), true);
             sign.Click += (_, _) => DoSign();
+            sign.IsDefault = true;    // Enter
             var cancel = MakeButton(L("Str_Sign_Cancel"), false);
             cancel.Margin = new Thickness(8, 0, 0, 0);
             cancel.Click += (_, _) => { DialogResult = false; Close(); };
+            cancel.IsCancel = true;   // Esc
             btnRow.Children.Add(sign);
             btnRow.Children.Add(cancel);
             body.Children.Add(btnRow);

--- a/StampWindow.cs
+++ b/StampWindow.cs
@@ -141,10 +141,12 @@ namespace KillerPDF
             var actionRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
             var cancelBtn = UiKit.Make(S("Str_Tf_Cancel"), false);
             cancelBtn.Click += (_, _2) => { Applied = false; Close(); };
+            cancelBtn.IsCancel = true;   // Esc
             cancelBtn.Margin = new Thickness(0, 0, 8, 0);
             actionRow.Children.Add(cancelBtn);
             _applyBtn = UiKit.Make(S("Str_Tf_Apply"), true);
             _applyBtn.Click += (_, _2) => CommitAndClose();
+            _applyBtn.IsDefault = true;   // Enter
             actionRow.Children.Add(_applyBtn);
             bottom.Children.Add(actionRow);
             DockPanel.SetDock(bottom, Dock.Bottom);

--- a/TransformWindow.cs
+++ b/TransformWindow.cs
@@ -112,9 +112,11 @@ namespace KillerPDF
             var cancelBtn = UiKit.Make(S("Str_Tf_Cancel"), false);
             cancelBtn.Margin = new Thickness(0, 0, 8, 0);
             cancelBtn.Click += (_, _2) => { Applied = false; Close(); };
+            cancelBtn.IsCancel = true;   // Esc
             actionRow.Children.Add(cancelBtn);
             var applyBtn = UiKit.Make(S("Str_Tf_Apply"), true);
             applyBtn.Click += (_, _2) => CommitAndClose();
+            applyBtn.IsDefault = true;   // Enter
             actionRow.Children.Add(applyBtn);
             bottom.Children.Add(actionRow);
             DockPanel.SetDock(bottom, Dock.Bottom);


### PR DESCRIPTION
Mark each dialog's primary button IsDefault and its cancel button IsCancel, so Enter confirms and Esc cancels consistently across the print, message, document info, sign, colour picker, stamp and transform dialogs.