### PR TITLE
Text selection + text highlighter (flowing, Chrome-style)

### DIFF
--- a/Annotations.cs
+++ b/Annotations.cs
@@ -1127,6 +1127,16 @@ namespace KillerPDF
                 case EditTool.Strikethrough:
                 case EditTool.Underline:
                     ClearSelection();
+                    // Text highlight: with the Highlight tool over the PDF's text (not the eraser, not box
+                    // mode), drag to highlight the actual text runs (flowing), like a real highlighter. Falls
+                    // through to the freeform box for non-text, the eraser, box mode, and strike/underline.
+                    if (_currentTool == EditTool.Highlight && !_highlightErase && !BoxTextSelectMode
+                        && TextBeginDrag(pageIdx, pos))
+                    {
+                        _activeCanvas.CaptureMouse();
+                        e.Handled = true;
+                        break;
+                    }
                     _isDrawing = true;
                     _drawStart = pos;
                     var previewFill = _currentTool == EditTool.Highlight
@@ -1762,11 +1772,18 @@ namespace KillerPDF
                 return;
             }
 
-            // Flowing text selection release: finalise (copy + keep for Ctrl+C).
+            // Flowing text drag release. A click with no real movement isn't a selection - just clear it, so
+            // clicking on text doesn't copy a stray char or lay a 1-char highlight. A real drag commits: the
+            // Highlight tool lays highlights over the selected text runs; the Select tool copies the text.
             if (_textDragging)
             {
-                TextEndDrag();
-                (_gestureCanvas ?? _activeCanvas)?.ReleaseMouseCapture();
+                var gcv = _gestureCanvas ?? _activeCanvas;
+                var upPos = e.GetPosition(gcv);
+                bool moved = Math.Abs(upPos.X - _textDragStartPt.X) >= 4 || Math.Abs(upPos.Y - _textDragStartPt.Y) >= 4;
+                if (!moved)                                  ClearTextSelection();
+                else if (_currentTool == EditTool.Highlight) CommitTextHighlight();
+                else                                         TextEndDrag();
+                gcv?.ReleaseMouseCapture();
                 e.Handled = true;
                 return;
             }

--- a/Annotations.cs
+++ b/Annotations.cs
@@ -244,6 +244,10 @@ namespace KillerPDF
             // Search highlights live on this same canvas and were wiped by the clear above; repaint
             // them last so they sit on top and survive every re-render and continuous scroll.
             ApplySearchHighlights(pageIndex, _activeCanvas);
+
+            // The text-selection highlight also lives on this canvas and was wiped by the clear above;
+            // repaint it (no-op unless the current selection is on this page) so it survives re-renders.
+            RepaintTextSelection(pageIndex);
         }
 
         // Decode a placed annotation's Base64 image once and cache the frozen result on the annotation,
@@ -1012,6 +1016,11 @@ namespace KillerPDF
                         if (StampHitTest(pageIdx, pos)) { OpenStampTool(); e.Handled = true; return; }
                         ClearSelection();
                         ClearTextSelection();
+                        // A user-placed text box under the cursor is re-edited (below). Otherwise, if the
+                        // double-click landed on the PDF's own text, select that word (Chrome-style).
+                        bool overTextAnnot = _annotations.TryGetValue(pageIdx, out var dcAnnots)
+                            && dcAnnots.OfType<TextAnnotation>().Any(a => HitTestAnnotation(a, pos, out _));
+                        if (!overTextAnnot && SelectWordAt(pageIdx, pos)) { e.Handled = true; return; }
                         EditTextAtPosition(pos, pageIdx);
                         e.Handled = true;
                     }
@@ -1070,20 +1079,31 @@ namespace KillerPDF
                             if (!shiftSel) ClearSelection();
                             ClearTextSelection();
                             if (_viewMode == ViewMode.Grid && !shiftSel) PageList.SelectedIndex = pageIdx;  // grid: click selects the page
-                            _isSelecting = true;
-                            _selectStart = pos;
-                            _selectRect = new Rectangle
+                            // Familiar flowing text selection: a plain click on the PDF's text starts a
+                            // click-drag character selection. Shift-drag, box mode, or a click on blank
+                            // space fall through to the marquee (annotation multi-select / OCR / legacy box).
+                            if (!shiftSel && !_ocrRegionMode && !BoxTextSelectMode && TextBeginDrag(pageIdx, pos))
                             {
-                                Fill = AccentBrush(40),
-                                Stroke = AccentBrush(150),
-                                StrokeThickness = 1,
-                                Width = 0, Height = 0,
-                                IsHitTestVisible = false
-                            };
-                            MarqueeLayer.Children.Add(_selectRect);
-                            UpdateMarquee(pos, pos);
-                            _activeCanvas.CaptureMouse();
-                            e.Handled = true;
+                                _activeCanvas.CaptureMouse();
+                                e.Handled = true;
+                            }
+                            else
+                            {
+                                _isSelecting = true;
+                                _selectStart = pos;
+                                _selectRect = new Rectangle
+                                {
+                                    Fill = AccentBrush(40),
+                                    Stroke = AccentBrush(150),
+                                    StrokeThickness = 1,
+                                    Width = 0, Height = 0,
+                                    IsHitTestVisible = false
+                                };
+                                MarqueeLayer.Children.Add(_selectRect);
+                                UpdateMarquee(pos, pos);
+                                _activeCanvas.CaptureMouse();
+                                e.Handled = true;
+                            }
                         }
                     }
                     break;
@@ -1311,7 +1331,7 @@ namespace KillerPDF
             // Safety: a drag/resize is in progress but the left button is no longer down - the mouse-up was
             // lost (typically because the app was in the background when the user released). Finish the
             // gesture now so the annotation stops following the cursor and the canvas frees its capture.
-            if (e.LeftButton != MouseButtonState.Pressed && (_isDraggingAnnot || _isResizingSig))
+            if (e.LeftButton != MouseButtonState.Pressed && (_isDraggingAnnot || _isResizingSig || _textDragging))
             {
                 FinishStuckGesture();
                 return;
@@ -1505,7 +1525,14 @@ namespace KillerPDF
                 return;
             }
 
-            // Text selection drag
+            // Flowing text selection: extend to the char under the pointer.
+            if (_textDragging)
+            {
+                TextExtendDrag(e.GetPosition(gc));
+                return;
+            }
+
+            // Text selection drag (box marquee)
             if (_isSelecting && _selectRect is not null)
             {
                 // Raw (un-clamped) pointer so the marquee can extend past the start page onto the others;
@@ -1735,6 +1762,15 @@ namespace KillerPDF
                 return;
             }
 
+            // Flowing text selection release: finalise (copy + keep for Ctrl+C).
+            if (_textDragging)
+            {
+                TextEndDrag();
+                (_gestureCanvas ?? _activeCanvas)?.ReleaseMouseCapture();
+                e.Handled = true;
+                return;
+            }
+
             // Handle text selection release
             if (_isSelecting)
             {
@@ -1810,8 +1846,11 @@ namespace KillerPDF
                         foreach (var (a, b, cv) in hits) ToggleMultiSelect(a, b, cv);
                         SetStatus($"Selected {hits.Count} annotation{(hits.Count == 1 ? "" : "s")}");
                     }
-                    else
+                    else if (BoxTextSelectMode)
                     {
+                        // Legacy box text-selection (opt-in): copy the words inside the dragged rectangle.
+                        // In the default flowing mode this path is skipped - a blank-area drag that caught
+                        // no annotations simply selects nothing.
                         ExtractTextFromRegion(pageIdx, startRect);
                     }
                 }
@@ -2284,6 +2323,7 @@ namespace KillerPDF
             _resizeSigAnnot = null;
             _resizeInkOrigPoints = null;
             _dragGroupOrig.Clear();
+            CancelTextDrag();   // also cancel a stuck flowing text drag and free its capture
 
             // Release whatever element grabbed the mouse for this gesture (and the active canvas, in case).
             if (Mouse.Captured is FrameworkElement cap) cap.ReleaseMouseCapture();

--- a/Links.cs
+++ b/Links.cs
@@ -160,8 +160,9 @@ namespace KillerPDF
 
         // Clipboard COM calls throw when another app is holding the clipboard open; swallow so a copy
         // never crashes the app (the worst case is the copy silently not happening).
-        private static void TrySetClipboard(string text)
+        private static void TrySetClipboard(string? text)
         {
+            if (string.IsNullOrEmpty(text)) return;
             try { Clipboard.SetText(text); } catch { }
         }
 

--- a/Links.cs
+++ b/Links.cs
@@ -344,6 +344,7 @@ namespace KillerPDF
         /// closes; the path check in EnsureLinkPdfiumDoc is the backstop for anything not closed here.</summary>
         private void CloseLinkPdfiumDoc()
         {
+            CloseTextPage();   // text-page/page handles are children of this doc - release them first
             if (_linkPdfiumDoc != IntPtr.Zero)
             {
                 try { FPDF_CloseDocument(_linkPdfiumDoc); } catch { }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2369,19 +2369,59 @@
                                                  Checked="ViewGridRadio_Checked"/>
                         </StackPanel>
 
-                    <!-- Links: behaviour toggles for PDF hyperlinks. Plain checkboxes (not the picker
-                         accordion the other sections use) since these are independent on/off switches;
-                         more toggles drop straight in under this subheader. -->
-                    <TextBlock Text="{DynamicResource Str_LinksSection}" Style="{StaticResource SettingsSubheader}" Margin="0,12,0,8"/>
-                    <CheckBox x:Name="LinkConfirmCheck" Content="{DynamicResource Str_LinkConfirmSetting}"
-                              Style="{StaticResource ThemeCheck}"
-                              Checked="LinkConfirmCheck_Toggled" Unchecked="LinkConfirmCheck_Toggled"/>
-
-                    <!-- Text selection: flowing (browser/Word-style) by default; the legacy box drag is opt-in. -->
-                    <TextBlock Text="Selection" Style="{StaticResource SettingsSubheader}" Margin="0,12,0,8"/>
-                    <CheckBox x:Name="BoxSelectCheck" Content="Box text selection (drag a rectangle)"
-                              Style="{StaticResource ThemeCheck}"
-                              Checked="BoxSelectCheck_Toggled" Unchecked="BoxSelectCheck_Toggled"/>
+                    <!-- Behaviour: our added on/off toggles, consolidated into one collapsible section that
+                         matches the pickers above. New toggles just drop into BehaviourSubmenu below. -->
+                    <TextBlock Text="{DynamicResource Str_BehaviourSection}" Style="{StaticResource SettingsSubheader}" Margin="0,12,0,8"/>
+                    <Grid Margin="0,0,0,4">
+                        <ToggleButton x:Name="BehaviourMenuButton"
+                                      Checked="SettingsMenu_Toggled" Unchecked="SettingsMenu_Toggled"
+                                      Cursor="Hand" FocusVisualStyle="{x:Null}"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border x:Name="RowBd" Background="Transparent" Margin="-10,0,2,0" Padding="10,4,10,4" CornerRadius="3">
+                                        <ContentPresenter/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="RowBd" Property="Background" Value="{DynamicResource BgHover}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsChecked" Value="True">
+                                            <Setter TargetName="RowBd" Property="Background" Value="{DynamicResource SettingsOpenRowBg}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                            <DockPanel LastChildFill="True">
+                                <TextBlock DockPanel.Dock="Right"
+                                           FontFamily="Segoe MDL2 Assets" FontSize="10"
+                                           VerticalAlignment="Center" Margin="6,0,0,0"
+                                           Foreground="{DynamicResource TextSecondary}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="&#xE70E;"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
+                                                    <Setter Property="Text" Value="&#xE70D;"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Text="{DynamicResource Str_BehaviourGroupLabel}" Style="{StaticResource SettingsAccentValue}"
+                                           Foreground="{DynamicResource TextPrimary}"/>
+                            </DockPanel>
+                        </ToggleButton>
+                    </Grid>
+                    <StackPanel x:Name="BehaviourSubmenu" Visibility="Collapsed" Margin="2,2,0,6">
+                        <CheckBox x:Name="LinkConfirmCheck" Content="{DynamicResource Str_LinkConfirmSetting}"
+                                  Style="{StaticResource ThemeCheck}"
+                                  Checked="LinkConfirmCheck_Toggled" Unchecked="LinkConfirmCheck_Toggled"/>
+                        <CheckBox x:Name="BoxSelectCheck" Content="{DynamicResource Str_BoxSelectSetting}"
+                                  Style="{StaticResource ThemeCheck}"
+                                  Checked="BoxSelectCheck_Toggled" Unchecked="BoxSelectCheck_Toggled"/>
+                    </StackPanel>
                 </StackPanel>
                 </ScrollViewer>
                 </Grid>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2376,6 +2376,12 @@
                     <CheckBox x:Name="LinkConfirmCheck" Content="{DynamicResource Str_LinkConfirmSetting}"
                               Style="{StaticResource ThemeCheck}"
                               Checked="LinkConfirmCheck_Toggled" Unchecked="LinkConfirmCheck_Toggled"/>
+
+                    <!-- Text selection: flowing (browser/Word-style) by default; the legacy box drag is opt-in. -->
+                    <TextBlock Text="Selection" Style="{StaticResource SettingsSubheader}" Margin="0,12,0,8"/>
+                    <CheckBox x:Name="BoxSelectCheck" Content="Box text selection (drag a rectangle)"
+                              Style="{StaticResource ThemeCheck}"
+                              Checked="BoxSelectCheck_Toggled" Unchecked="BoxSelectCheck_Toggled"/>
                 </StackPanel>
                 </ScrollViewer>
                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -287,7 +287,7 @@ namespace KillerPDF
             // the mouse-up can be lost and the dragged annotation would stay glued to the cursor with the
             // canvas still holding mouse capture. End any in-progress gesture on deactivate so control is
             // restored the moment the user comes back.
-            Deactivated += (_, _) => { if (_isDraggingAnnot || _isResizingSig) FinishStuckGesture(); };
+            Deactivated += (_, _) => { if (_isDraggingAnnot || _isResizingSig || _textDragging) FinishStuckGesture(); };
             _pageContentGrid = (Grid)FindName("PageContentGrid")!;
             _toolSelectBtn = (Button)FindName("ToolSelectBtn")!;
             _toolTextBtn = (Button)FindName("ToolTextBtn")!;

--- a/Selection.cs
+++ b/Selection.cs
@@ -105,6 +105,8 @@ namespace KillerPDF
                 _activeCanvas.Children.Remove(_selectRect);
                 _selectRect = null;
             }
+            CancelTextDrag();                // cancel any in-progress flowing drag + free its capture
+            ClearTextSelectionHighlight();   // and drop the word/char highlight rects + forget the range
             _selectedText = null;
         }
 

--- a/SettingsPanel.cs
+++ b/SettingsPanel.cs
@@ -79,7 +79,7 @@ namespace KillerPDF
             SlideSettingsOpen();
         }
 
-        private const double SettingsPanelWidth = 228;
+        private const double SettingsPanelWidth = 248;
 
         // Expands the panel out of the sidebar (Width grows from the flush left edge). Clipped while
         // animating so it reveals left-to-right; clip is dropped at the end so the drop shadow shows.
@@ -137,6 +137,7 @@ namespace KillerPDF
             if (btn == ToolbarMenuButton) return ToolbarSubmenu;
             if (btn == ViewMenuButton)    return ViewSubmenu;
             if (btn == SidebarMenuButton) return SidebarSubmenu;
+            if (btn == BehaviourMenuButton) return BehaviourSubmenu;
             return null;
         }
 

--- a/SettingsPanel.cs
+++ b/SettingsPanel.cs
@@ -72,6 +72,8 @@ namespace KillerPDF
             SidebarCurrentLabel.Text     = Loc(_sidebarRight ? "Str_Sidebar_Right" : "Str_Sidebar_Left");
             // Sync the Links section: confirm is ON unless the user has opted out ("Don't ask again").
             LinkConfirmCheck.IsChecked = App.GetSetting(SkipLinkConfirmSetting) != "1";
+            // Sync the Selection section: box text-select is opt-in (default = flowing selection).
+            BoxSelectCheck.IsChecked = App.GetSetting("BoxTextSelect") == "1";
             PositionSettingsPanel();
             SettingsOverlay.Visibility = Visibility.Visible;
             SlideSettingsOpen();
@@ -319,6 +321,14 @@ namespace KillerPDF
         {
             if (LinkConfirmCheck.IsChecked == true) App.RemoveSetting(SkipLinkConfirmSetting);
             else                                    App.SetSetting(SkipLinkConfirmSetting, "1");
+        }
+
+        // Selection section: opt in to the legacy box text-selection (drag a rectangle to copy the words
+        // inside) instead of the default flowing character selection. Read live via BoxTextSelectMode.
+        private void BoxSelectCheck_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (BoxSelectCheck.IsChecked == true) App.SetSetting("BoxTextSelect", "1");
+            else                                  App.RemoveSetting("BoxTextSelect");
         }
 
         private void OnThemeChanged()

--- a/Strings/en-US.xaml
+++ b/Strings/en-US.xaml
@@ -155,6 +155,9 @@
     <sys:String x:Key="Str_Ctx_RemoveLink">Remove Link from PDF</sys:String>
     <sys:String x:Key="Str_LinksSection">LINKS</sys:String>
     <sys:String x:Key="Str_LinkConfirmSetting">Confirm before opening links</sys:String>
+    <sys:String x:Key="Str_BehaviourSection">BEHAVIOUR</sys:String>
+    <sys:String x:Key="Str_BehaviourGroupLabel">Links &amp; text</sys:String>
+    <sys:String x:Key="Str_BoxSelectSetting">Box text selection</sys:String>
     <sys:String x:Key="Str_InvalidRange">Invalid range — use e.g. 1-3,5,7</sys:String>
     <sys:String x:Key="Str_CropNoDoc">Crop: no document open</sys:String>
     <sys:String x:Key="Str_CropNoPage">Crop: no page selected</sys:String>

--- a/TextSelection.cs
+++ b/TextSelection.cs
@@ -1,16 +1,14 @@
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Shapes;
-using Docnet.Core;
 
 namespace KillerPDF
 {
     public partial class MainWindow
     {
         // ============================================================
-        // PDFium text-selection engine (Phase 2 - foundation)
+        // PDFium text-selection engine
         //
         // Chrome-style character selection needs: char-index-at-a-point, per-char boxes, the selection
         // rectangles for a char range (for glyph-level highlighting), and range->text. PdfPig (used for
@@ -185,7 +183,7 @@ namespace KillerPDF
             return new string(chars);
         }
 
-        // --- selection state, word + flowing selection, highlight rendering (Increment 2a/2b) ---
+        // --- text selection state, word + flowing drag selection, and highlight rendering ---
 
         private readonly List<Rectangle> _textSelRects = [];   // currently rendered highlight rects
         private int  _textSelPage    = -1;                     // page of the current selection (for repaint)
@@ -194,6 +192,7 @@ namespace KillerPDF
         private bool _textDragging;                            // a flowing text drag is in progress
         private int  _textAnchorChar = -1;                     // char index where a flowing drag started
         private int  _textDragPage   = -1;                     // page the flowing selection is on (v1: single page)
+        private Point _textDragStartPt;                        // canvas point the drag began at (click-vs-drag test)
 
         // Legacy box text-selection (Settings toggle). Default off = familiar flowing drag selection.
         private bool BoxTextSelectMode => App.GetSetting("BoxTextSelect") == "1";
@@ -287,9 +286,10 @@ namespace KillerPDF
         {
             int ch = TextCharAtCanvasPoint(pageIndex, canvasPos, 6.0);
             if (ch < 0) return false;
-            _textDragging   = true;
-            _textAnchorChar = ch;
-            _textDragPage   = pageIndex;
+            _textDragging    = true;
+            _textAnchorChar  = ch;
+            _textDragPage    = pageIndex;
+            _textDragStartPt = canvasPos;
             RenderTextSelection(pageIndex, ch, 1);         // seed the highlight with the anchor char
             _selectedText = TextRangeString(pageIndex, ch, 1);
             return true;
@@ -317,6 +317,35 @@ namespace KillerPDF
             TrySetClipboard(text);
             int n = text.Length;
             SetStatus($"Copied {n} character{(n == 1 ? "" : "s")}");
+        }
+
+        // Highlight-tool release over text: lay a Fill highlight annotation over each selected text-run rect
+        // (one per visual line) in the current highlight colour, grouped as a single undo. Then clears the
+        // transient blue selection highlight so only the yellow highlight annotations remain.
+        private void CommitTextHighlight()
+        {
+            int page = _textSelPage, start = _textSelStart, count = _textSelCount;
+            if (count <= 0) { ClearTextSelection(); return; }
+
+            var rects = TextRangeRects(page, start, count);
+            if (!_annotations.TryGetValue(page, out var list)) { list = []; _annotations[page] = list; }
+            var group = new List<PageAnnotation>();
+            foreach (var r in rects)
+            {
+                if (r.Width < 1 || r.Height < 1) continue;
+                var ha = new HighlightAnnotation { PageIndex = page, Bounds = r, Style = HighlightStyle.Fill };
+                ha.SetColor(_highlightColor);
+                list.Add(ha);
+                group.Add(ha);
+            }
+
+            bool wasDirty = _isDirty;
+            ClearTextSelection();   // drop the transient selection highlight + reset range/drag
+            if (group.Count == 0) return;
+            _undoStack.Push(new UndoEntry(UndoKind.AnnotationGroup, page, WasDirty: wasDirty, AnnotGroup: group));
+            MarkDirty();
+            RenderAllAnnotations(page);
+            SetStatus($"Highlighted {group.Count} line{(group.Count == 1 ? "" : "s")}");
         }
     }
 }

--- a/TextSelection.cs
+++ b/TextSelection.cs
@@ -1,5 +1,8 @@
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
 using Docnet.Core;
 
 namespace KillerPDF
@@ -180,6 +183,140 @@ namespace KillerPDF
             var chars = new char[written - 1];               // drop the terminator
             for (int i = 0; i < chars.Length; i++) chars[i] = (char)buf[i];
             return new string(chars);
+        }
+
+        // --- selection state, word + flowing selection, highlight rendering (Increment 2a/2b) ---
+
+        private readonly List<Rectangle> _textSelRects = [];   // currently rendered highlight rects
+        private int  _textSelPage    = -1;                     // page of the current selection (for repaint)
+        private int  _textSelStart   = -1;                     // first char index of the current selection
+        private int  _textSelCount   = 0;                      // char count of the current selection
+        private bool _textDragging;                            // a flowing text drag is in progress
+        private int  _textAnchorChar = -1;                     // char index where a flowing drag started
+        private int  _textDragPage   = -1;                     // page the flowing selection is on (v1: single page)
+
+        // Legacy box text-selection (Settings toggle). Default off = familiar flowing drag selection.
+        private bool BoxTextSelectMode => App.GetSetting("BoxTextSelect") == "1";
+
+        /// <summary>
+        /// Double-click entry: selects the word under a canvas point on pageIndex. Returns false if there's
+        /// no selectable PDF text there (the caller then falls back to its existing double-click behaviour).
+        /// Highlights the word and copies it (the app's convention that a selection copies), and leaves it in
+        /// _selectedText so Ctrl+C works too.
+        /// </summary>
+        private bool SelectWordAt(int pageIndex, Point canvasPos)
+        {
+            int ch = TextCharAtCanvasPoint(pageIndex, canvasPos);
+            if (ch < 0) return false;
+            var (start, count) = TextWordRangeAt(pageIndex, ch);
+            if (count <= 0) return false;
+
+            RenderTextSelection(pageIndex, start, count);
+            var text = TextRangeString(pageIndex, start, count);
+            _selectedText = text;
+            if (!string.IsNullOrEmpty(text))
+            {
+                TrySetClipboard(text);
+                SetStatus($"Copied: {text}");
+            }
+            return true;
+        }
+
+        // Records the selection range, then (re)draws its highlight.
+        private void RenderTextSelection(int pageIndex, int start, int count)
+        {
+            _textSelPage = pageIndex; _textSelStart = start; _textSelCount = count;
+            DrawTextSelectionHighlight();
+        }
+
+        // Draws one translucent rect per visual line run for the current selection range. Targets the
+        // SELECTION's own page canvas (CanvasForPage), not _activeCanvas - which async tile renders can
+        // re-point to a neighbour page mid-gesture (the wrong-tile hazard the marquee's _gestureCanvas avoids).
+        private void DrawTextSelectionHighlight()
+        {
+            RemoveTextSelectionRects();
+            if (_textSelCount <= 0) return;
+            var canvas = CanvasForPage(_textSelPage);
+            var fill = AccentBrush(70);
+            foreach (var r in TextRangeRects(_textSelPage, _textSelStart, _textSelCount))
+            {
+                var rect = new Rectangle { Width = r.Width, Height = r.Height, Fill = fill, IsHitTestVisible = false };
+                Canvas.SetLeft(rect, r.X);
+                Canvas.SetTop(rect, r.Y);
+                canvas.Children.Add(rect);
+                _textSelRects.Add(rect);
+            }
+        }
+
+        // Re-draws the selection highlight after a page repaint. RenderAllAnnotations clears the page canvas's
+        // children (which would wipe the highlight while _selectedText stayed live), so it calls this at the
+        // end. No-op unless the current selection is on the repainted page.
+        private void RepaintTextSelection(int pageIndex)
+        {
+            if (_textSelCount > 0 && _textSelPage == pageIndex) DrawTextSelectionHighlight();
+        }
+
+        // Removes just the rendered rects (keeps the selection range so it can be redrawn).
+        private void RemoveTextSelectionRects()
+        {
+            foreach (var r in _textSelRects)
+                (r.Parent as Canvas)?.Children.Remove(r);
+            _textSelRects.Clear();
+        }
+
+        // Clears the selection entirely: drops the rects AND forgets the range. Called from ClearTextSelection
+        // (single click / tool switch / starting a new selection).
+        private void ClearTextSelectionHighlight()
+        {
+            RemoveTextSelectionRects();
+            _textSelPage = -1; _textSelStart = -1; _textSelCount = 0;
+        }
+
+        // Cancels an in-progress flowing drag and releases the mouse capture. Safe no-op if none is active.
+        // Called from ClearTextSelection (tool switch) and FinishStuckGesture (lost mouse-up / deactivation).
+        private void CancelTextDrag()
+        {
+            if (!_textDragging) return;
+            _textDragging = false;
+            (_gestureCanvas ?? _activeCanvas)?.ReleaseMouseCapture();
+        }
+
+        // Mouse-down: begin a flowing text selection if the point is on the page's text. Returns false when
+        // there's no char there (the caller then falls back to the box marquee). Anchors at that char.
+        private bool TextBeginDrag(int pageIndex, Point canvasPos)
+        {
+            int ch = TextCharAtCanvasPoint(pageIndex, canvasPos, 6.0);
+            if (ch < 0) return false;
+            _textDragging   = true;
+            _textAnchorChar = ch;
+            _textDragPage   = pageIndex;
+            RenderTextSelection(pageIndex, ch, 1);         // seed the highlight with the anchor char
+            _selectedText = TextRangeString(pageIndex, ch, 1);
+            return true;
+        }
+
+        // Mouse-move: extend the selection from the anchor to the char under the pointer (either direction).
+        private void TextExtendDrag(Point canvasPos)
+        {
+            if (!_textDragging) return;
+            int focus = TextCharAtCanvasPoint(_textDragPage, canvasPos, 10.0);
+            if (focus < 0) return;                          // off text / in a gap: keep the current selection
+            int start = Math.Min(_textAnchorChar, focus);
+            int count = Math.Abs(focus - _textAnchorChar) + 1;
+            RenderTextSelection(_textDragPage, start, count);
+            _selectedText = TextRangeString(_textDragPage, start, count);
+        }
+
+        // Mouse-up: finish the flowing selection - copy it (the app's selection-copies convention) and leave
+        // it in _selectedText so Ctrl+C works. The highlight stays until the next click / tool switch.
+        private void TextEndDrag()
+        {
+            _textDragging = false;
+            var text = _selectedText;
+            if (text is null || text.Length == 0) return;
+            TrySetClipboard(text);
+            int n = text.Length;
+            SetStatus($"Copied {n} character{(n == 1 ? "" : "s")}");
         }
     }
 }

--- a/TextSelection.cs
+++ b/TextSelection.cs
@@ -1,0 +1,185 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using Docnet.Core;
+
+namespace KillerPDF
+{
+    public partial class MainWindow
+    {
+        // ============================================================
+        // PDFium text-selection engine (Phase 2 - foundation)
+        //
+        // Chrome-style character selection needs: char-index-at-a-point, per-char boxes, the selection
+        // rectangles for a char range (for glyph-level highlighting), and range->text. PdfPig (used for
+        // the old box/word marquee) exposes none of these conveniently; PDFium's FPDFText_* API is built
+        // for exactly this and reads object-stream PDFs (same reason links moved to PDFium). We reuse the
+        // cached document handle from Links.cs (_linkPdfiumDoc via EnsureLinkPdfiumDoc) and cache one text
+        // page for the active document page on top of it. The page + text-page handles are children of the
+        // cached doc, so CloseLinkPdfiumDoc() also closes them (see the CloseTextPage() call there).
+        //
+        // Coordinates: PDFium text coords are PDF points, origin bottom-left, Y up. Canvas coords are the
+        // page's render-dim space (the same space _renderDims and the link overlays use), origin top-left,
+        // Y down. CanvasToPdfPoint / PdfRectToCanvasRect below convert between them.
+        // ============================================================
+
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr FPDFText_LoadPage(IntPtr page);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void FPDFText_ClosePage(IntPtr textPage);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int FPDFText_CountChars(IntPtr textPage);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int FPDFText_GetCharIndexAtPos(IntPtr textPage, double x, double y, double xTolerance, double yTolerance);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern uint FPDFText_GetUnicode(IntPtr textPage, int index);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int FPDFText_CountRects(IntPtr textPage, int startIndex, int count);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool FPDFText_GetRect(IntPtr textPage, int rectIndex, out double left, out double top, out double right, out double bottom);
+        [DllImport("pdfium.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int FPDFText_GetText(IntPtr textPage, int startIndex, int count, [Out] ushort[] result);
+
+        // Cached text page for the active document page. Both handles are children of _linkPdfiumDoc, so
+        // CloseLinkPdfiumDoc() calls CloseTextPage(). Only touched on the UI thread (Select-tool handlers).
+        private IntPtr _textPage        = IntPtr.Zero;   // FPDFText text-page handle
+        private IntPtr _textPageParent  = IntPtr.Zero;   // the FPDF_LoadPage handle backing _textPage
+        private int    _textPageIndex   = -1;
+
+        /// <summary>
+        /// Loads (and caches) the PDFium text page for pageIndex, reusing the shared document handle.
+        /// Returns IntPtr.Zero if unavailable. Reopens when the page or the working file changes.
+        /// </summary>
+        private IntPtr EnsureTextPage(int pageIndex)
+        {
+            if (_textPage != IntPtr.Zero && _textPageIndex == pageIndex && _linkPdfiumDocPath == _currentFile)
+                return _textPage;
+
+            CloseTextPage();
+            IntPtr doc = EnsureLinkPdfiumDoc();
+            if (doc == IntPtr.Zero) return IntPtr.Zero;
+
+            IntPtr page = FPDF_LoadPage(doc, pageIndex);
+            if (page == IntPtr.Zero) return IntPtr.Zero;
+            IntPtr textPage = FPDFText_LoadPage(page);
+            if (textPage == IntPtr.Zero) { FPDF_ClosePage(page); return IntPtr.Zero; }
+
+            _textPageParent = page;
+            _textPage       = textPage;
+            _textPageIndex  = pageIndex;
+            return _textPage;
+        }
+
+        /// <summary>Closes the cached text page + its backing page handle. Called on page/doc change and
+        /// from CloseLinkPdfiumDoc() (the text page is a child of the doc it was loaded from).</summary>
+        private void CloseTextPage()
+        {
+            if (_textPage != IntPtr.Zero)
+            {
+                try { FPDFText_ClosePage(_textPage); } catch { }
+                _textPage = IntPtr.Zero;
+            }
+            if (_textPageParent != IntPtr.Zero)
+            {
+                try { FPDF_ClosePage(_textPageParent); } catch { }
+                _textPageParent = IntPtr.Zero;
+            }
+            _textPageIndex = -1;
+        }
+
+        // --- coordinate conversion (canvas render-dim space <-> PDF points) ---
+
+        // PDF page size in points for the cached text page, or A4 fallback.
+        private (double w, double h) TextPagePdfSize()
+        {
+            if (_textPageParent == IntPtr.Zero) return (595.28, 841.89);
+            double w = FPDF_GetPageWidth(_textPageParent);
+            double h = FPDF_GetPageHeight(_textPageParent);
+            if (w <= 0) w = 595.28;
+            if (h <= 0) h = 841.89;
+            return (w, h);
+        }
+
+        // Canvas point (render-dim units) -> PDF point (points, origin bottom-left).
+        private bool CanvasToPdfPoint(int pageIndex, Point canvas, out double pdfX, out double pdfY)
+        {
+            pdfX = pdfY = 0;
+            if (!_renderDims.TryGetValue(pageIndex, out var rd) || rd.w <= 0 || rd.h <= 0) return false;
+            var (pw, ph) = TextPagePdfSize();
+            pdfX = canvas.X * (pw / rd.w);
+            pdfY = ph - canvas.Y * (ph / rd.h);   // flip Y
+            return true;
+        }
+
+        // PDF rect (left/top/right/bottom in points, Y up) -> canvas Rect (render-dim units, Y down).
+        private Rect PdfRectToCanvasRect(int pageIndex, double left, double top, double right, double bottom)
+        {
+            if (!_renderDims.TryGetValue(pageIndex, out var rd)) return Rect.Empty;
+            var (pw, ph) = TextPagePdfSize();
+            double x = left  / pw * rd.w;
+            double y = (ph - top) / ph * rd.h;
+            double w = (right - left) / pw * rd.w;
+            double h = (top - bottom) / ph * rd.h;
+            return new Rect(x, y, Math.Max(0, w), Math.Max(0, h));
+        }
+
+        // --- query helpers (operate on the cached text page for pageIndex) ---
+
+        // Char index under a canvas point, or -1. Tolerance is a few PDF points so a near-miss still hits.
+        private int TextCharAtCanvasPoint(int pageIndex, Point canvas, double tolPts = 4.0)
+        {
+            IntPtr tp = EnsureTextPage(pageIndex);
+            if (tp == IntPtr.Zero) return -1;
+            if (!CanvasToPdfPoint(pageIndex, canvas, out double px, out double py)) return -1;
+            int idx = FPDFText_GetCharIndexAtPos(tp, px, py, tolPts, tolPts);
+            return idx < 0 ? -1 : idx;
+        }
+
+        // Expands a char index to the word around it as a [start, endExclusive) range, using whitespace
+        // as the boundary. Returns (start, count); count 0 if the index isn't on a word char.
+        private (int start, int count) TextWordRangeAt(int pageIndex, int charIndex)
+        {
+            IntPtr tp = EnsureTextPage(pageIndex);
+            if (tp == IntPtr.Zero || charIndex < 0) return (charIndex, 0);
+            int total = FPDFText_CountChars(tp);
+            if (charIndex >= total) return (charIndex, 0);
+
+            static bool IsWordChar(uint u) => u != 0 && !char.IsWhiteSpace((char)u);
+            if (!IsWordChar(FPDFText_GetUnicode(tp, charIndex))) return (charIndex, 0);
+
+            int start = charIndex;
+            while (start > 0 && IsWordChar(FPDFText_GetUnicode(tp, start - 1))) start--;
+            int end = charIndex;
+            while (end + 1 < total && IsWordChar(FPDFText_GetUnicode(tp, end + 1))) end++;
+            return (start, end - start + 1);
+        }
+
+        // Selection rectangles (canvas render-dim space) for a char range - one per visual line run.
+        private List<Rect> TextRangeRects(int pageIndex, int start, int count)
+        {
+            var rects = new List<Rect>();
+            IntPtr tp = EnsureTextPage(pageIndex);
+            if (tp == IntPtr.Zero || count <= 0) return rects;
+            int n = FPDFText_CountRects(tp, start, count);
+            for (int i = 0; i < n; i++)
+                if (FPDFText_GetRect(tp, i, out double l, out double t, out double r, out double b))
+                {
+                    var rect = PdfRectToCanvasRect(pageIndex, l, t, r, b);
+                    if (rect.Width >= 0.5 && rect.Height >= 0.5) rects.Add(rect);
+                }
+            return rects;
+        }
+
+        // Unicode text for a char range.
+        private string TextRangeString(int pageIndex, int start, int count)
+        {
+            IntPtr tp = EnsureTextPage(pageIndex);
+            if (tp == IntPtr.Zero || count <= 0) return string.Empty;
+            var buf = new ushort[count + 1];                 // +1 for PDFium's null terminator
+            int written = FPDFText_GetText(tp, start, count, buf);
+            if (written <= 1) return string.Empty;
+            var chars = new char[written - 1];               // drop the terminator
+            for (int i = 0; i < chars.Length; i++) chars[i] = (char)buf[i];
+            return new string(chars);
+        }
+    }
+}


### PR DESCRIPTION
Chrome / Word-style **text selection** and a **text highlighter**, replacing the box-marquee-for-text.

Now that #115 has merged, this is rebased onto the updated base: the link commits have dropped out, so the diff is just the text-selection work, and the new UI strings are localized (mirrors #115 - keys added to `en-US.xaml`, other languages fall back to English per `Strings/TRANSLATING.md`).

## What this adds

- **Flowing selection** (Select tool): click-drag over the PDF's text selects character-by-character, following the line/paragraph flow and highlighting as you go; copies on release and via Ctrl+C. Double-click selects a word.
- **Text highlighter** (Highlight tool): dragging over text lays a highlight over the actual text runs - one per visual line, in the current highlight colour, grouped as a single undo - like Acrobat, instead of a freeform box.
- The **box marquee is preserved** for its other jobs (annotation multi-select, OCR region) and as an opt-in legacy mode via **Settings -> Behaviour -> Box text selection**.
- A plain click (no drag) never lays a stray selection/highlight.

The Links and Selection toggles are consolidated into a single collapsible **Behaviour** section in Settings that matches the picker style used elsewhere.

Built on a PDFium `FPDFText_*` engine (char-index-at-point, per-char boxes, range->rects, range->text) over a cached text page, reusing the document handle from #115. Highlight rects are pinned to the selection's page and repaint after annotation re-renders; the drag is wired into the lost-mouse-up / deactivate / tool-switch safety nets.

## Notes for review

- Single-page scope. Cross-page selection is a v2 follow-up.
- New `Str_Behaviour*` / `Str_BoxSelectSetting` keys are in `en-US.xaml`; the old `Str_LinksSection` key is now unused (the section moved under Behaviour) but left in place harmlessly.
- Builds clean on `net48`; verified the app starts and the Behaviour settings render.
