### PR TITLE
Print: show a progress scrim instead of freezing the window

### DIFF
--- a/PrintPreviewWindow.cs
+++ b/PrintPreviewWindow.cs
@@ -297,7 +297,12 @@ namespace KillerPDF
             _ => (1, 1)
         };
 
-        private int SheetCount() => _pages.Length == 0 ? 0 : (_pages.Length + _nUp - 1) / _nUp;
+        // The page indices the preview walks AND the Print button sends - whatever range is typed in the
+        // Pages box (blank or unparseable falls back to every page, matching ParseRange). Driving the
+        // preview off this keeps it showing exactly the pages that will print (type "6" -> preview page 6).
+        private List<int> SelectedIndices() => ParseRange(_pagesBox.Text, _pages.Length);
+
+        private int SheetCount() => _pages.Length == 0 ? 0 : (SelectedIndices().Count + _nUp - 1) / _nUp;
 
         // Builds one sheet (aw x ah DIPs, white) holding the given source pages. 1-up honours the
         // scale mode + alignment + margin; N-up fits each page into its grid cell. Shared by the
@@ -639,6 +644,8 @@ namespace KillerPDF
                 Padding      = new Thickness(6, 4, 6, 4)
             };
             StyleTextBox(_pagesBox);
+            // Typing a range re-filters the preview to just those pages (jump back to the first one).
+            _pagesBox.TextChanged += (_, _) => { _previewIndex = 0; UpdatePreview(); };
             panel.Children.Add(_pagesBox);
             panel.Children.Add(new TextBlock
             {
@@ -830,20 +837,22 @@ namespace KillerPDF
             _previewHost.Children.Clear();
             if (_pages.Length == 0) { _pageLabel.Text = S("Str_Print_NoPages"); _renderLabel.Visibility = Visibility.Collapsed; return; }
 
-            int sheets = SheetCount();
+            var selected = SelectedIndices();
+            int sheets = Math.Max(1, (selected.Count + _nUp - 1) / _nUp);
             int sheet = Math.Max(0, Math.Min(_previewIndex, sheets - 1));
             _previewIndex = sheet;
 
-            // Source pages on this sheet (one for 1-up, up to _nUp for N-up).
+            // Source pages on this sheet, taken from the SELECTED set (one for 1-up, up to _nUp for N-up).
             var idxs = new System.Collections.Generic.List<int>();
-            for (int i = sheet * _nUp; i < Math.Min(_pages.Length, sheet * _nUp + _nUp); i++)
-                idxs.Add(i);
+            for (int i = sheet * _nUp; i < Math.Min(selected.Count, sheet * _nUp + _nUp); i++)
+                idxs.Add(selected[i]);
 
             // Page/sheet nav label is always shown; the "Rendering X / Y" line above it appears only while
-            // pages are still streaming in.
+            // pages are still streaming in. 1-up shows the real page number (so a filtered preview reads
+            // "Page 6 of 108"); N-up shows the sheet position within the selected set.
             _pageLabel.Text = _nUp > 1
                 ? $"Sheet {sheet + 1} of {sheets}"
-                : string.Format(S("Str_PageOf"), sheet + 1, _pages.Length);
+                : string.Format(S("Str_PageOf"), idxs.Count > 0 ? idxs[0] + 1 : 1, _pages.Length);
             UpdateRenderLabel();
 
             // If any page on this sheet hasn't rendered yet, show a spinner instead of composing.
@@ -1052,6 +1061,7 @@ namespace KillerPDF
                 // copy begins on a fresh front side.
                 int sheetsPerCopy = (indices.Count + _nUp - 1) / _nUp;
                 bool padForDuplex = _duplex && copies > 1 && (sheetsPerCopy % 2 == 1);
+                int composed = 0;   // yield to the dispatcher every so often so the spinner keeps turning
                 for (int copy = 0; copy < copies; copy++)
                 {
                     for (int start = 0; start < indices.Count; start += _nUp)
@@ -1069,6 +1079,11 @@ namespace KillerPDF
                         var pc = new PageContent();
                         ((IAddChild)pc).AddChild(fp);
                         fixedDoc.Pages.Add(pc);
+
+                        // Composing many high-res sheets can block long enough to stall the animation;
+                        // hand the UI thread a render pass every dozen sheets to keep the scrim alive.
+                        if (++composed % 12 == 0)
+                            await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
                     }
 
                     if (padForDuplex && copy < copies - 1)
@@ -1082,9 +1097,28 @@ namespace KillerPDF
                     }
                 }
 
-                pd.PrintDocument(fixedDoc.DocumentPaginator, "KillerPDF");
-                PrintedPageCount = indices.Count;
-                DialogResult = true;
+                // Spool ASYNCHRONOUSLY so the UI thread stays free and the spinner keeps turning while the
+                // job serializes to the spooler. PrintDialog.PrintDocument does this synchronously, which
+                // froze the animation until the printer had the whole document. The FixedDocument already
+                // carries the copy/duplex layout and `ticket` the orientation/color/duplex, so the output
+                // is identical to the old path (issue #83 copy handling unchanged - ticket.CopyCount stays 1).
+                var writer = PrintQueue.CreateXpsDocumentWriter(_queue);
+                var spooled = new TaskCompletionSource<bool>();
+                writer.WritingCompleted += (_, ev) =>
+                {
+                    if (ev.Error is not null)  spooled.TrySetException(ev.Error);
+                    else if (ev.Cancelled)     spooled.TrySetResult(false);
+                    else                       spooled.TrySetResult(true);
+                };
+                // Write the FixedDocument itself, NOT its DocumentPaginator: the paginator path makes the
+                // XPS serializer wrap each page's Visual in a fresh FixedPage, but the Visual already IS a
+                // FixedPage - "FixedPage cannot contain another FixedPage". The FixedDocument overload
+                // serializes the existing FixedPages directly.
+                writer.WriteAsync(fixedDoc, ticket);
+                bool ok = await spooled.Task;
+
+                PrintedPageCount = ok ? indices.Count : 0;
+                DialogResult = ok;
                 Close();
             }
             catch (Exception ex)

--- a/PrintPreviewWindow.cs
+++ b/PrintPreviewWindow.cs
@@ -957,7 +957,7 @@ namespace KillerPDF
             catch { /* settings are best-effort */ }
         }
 
-        private void DoPrint()
+        private async void DoPrint()
         {
             if (_queue == null)
             {
@@ -977,10 +977,24 @@ namespace KillerPDF
             int.TryParse(_copiesBox.Text?.Trim(), out int copies);
             if (copies < 1) copies = 1;
 
-            SavePrintPrefs();   // remember printer / orientation / color / two-sided for next time
+            // The 300 DPI re-rasterize below (plus the compose + spool) runs long enough on real
+            // documents that the window froze with no feedback - it read as a crash. Cover the card
+            // with a progress scrim, push the heavy rasterization onto a background thread, and only
+            // return to the PDF once the job is handed to the spooler.
+            var overlay = ShowPrintOverlay(out TextBlock statusText);
+            _printBtn.IsEnabled = false;
 
             try
             {
+                // Give the dispatcher one pass to actually paint the scrim BEFORE any work below.
+                // Building the PrintDialog and reading PrintableAreaWidth queries the printer driver and
+                // can stall for a beat; without this yield that stall happens while the old frame is still
+                // on screen, so the click-to-scrim change looks laggy. Resuming at Background priority
+                // (below Render) guarantees the scrim's render pass has run first.
+                await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
+
+                SavePrintPrefs();   // remember printer / orientation / color / two-sided for next time
+
                 var pd = new PrintDialog { PrintQueue = _queue };
                 var ticket = pd.PrintTicket;
                 // Copies are produced by replicating the page sequence in the FixedDocument below
@@ -999,21 +1013,34 @@ namespace KillerPDF
 
                 // Re-rasterize ONLY the selected pages at a true 300 DPI from the source, so the spooled
                 // output is crisp regardless of the lighter preview rasters. Held only for this print call.
+                // Frozen bitmaps cross threads freely, so the whole loop runs off the UI thread and reports
+                // "Preparing page X of N" back to the scrim, keeping the window painting throughout.
                 var hiPages = new BitmapSource?[_pages.Length];
                 var hiW = new int[_pages.Length];
                 var hiH = new int[_pages.Length];
-                using (var dr = DocLib.Instance.GetDocReader(_renderPath, new PageDimensions(300.0 / 72.0)))
+                int total = indices.Count;
+                await Task.Run(() =>
                 {
+                    using var dr = DocLib.Instance.GetDocReader(_renderPath, new PageDimensions(300.0 / 72.0));
+                    int done = 0;
                     foreach (int idx in indices)
                     {
+                        done++;
                         if (idx < 0 || idx >= _pages.Length) continue;
                         using var pr = dr.GetPageReader(idx);
                         int w = pr.GetPageWidth(), h = pr.GetPageHeight();
                         var bs = BitmapSource.Create(w, h, 96, 96, PixelFormats.Bgra32, null, pr.GetImage(), w * 4);
                         bs.Freeze();
                         hiPages[idx] = bs; hiW[idx] = w; hiH[idx] = h;
+                        int shown = done;
+                        try { statusText.Dispatcher.Invoke(() => statusText.Text = $"Preparing page {shown} of {total}…"); }
+                        catch { /* window closing */ }
                     }
-                }
+                });
+
+                statusText.Text = "Sending to printer…";
+                // Let the scrim repaint the new message before the UI-thread compose + spool below runs.
+                await System.Windows.Threading.Dispatcher.Yield(System.Windows.Threading.DispatcherPriority.Background);
 
                 var fixedDoc = new FixedDocument();
                 // Group the selected pages into sheets of _nUp and compose each sheet (margins +
@@ -1062,10 +1089,60 @@ namespace KillerPDF
             }
             catch (Exception ex)
             {
+                RemoveOverlay(overlay);   // drop the scrim so the error dialog isn't stuck behind it
+                _printBtn.IsEnabled = true;
                 KillerDialog.Show(this, $"Print failed:\n{ex.GetType().Name}: {ex.Message}",
                     "KillerPDF", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
+
+        // Full-card scrim with a spinner + live status line, shown while a print job rasterizes and
+        // spools so the window shows progress instead of freezing silently. Added over _rootGrid (which
+        // is already clipped to the card's rounded corners) and painted last, so it sits on top and its
+        // Background swallows clicks - the buttons underneath can't be re-triggered mid-print. Returns
+        // the scrim; `status` is its message line, updated as the job progresses.
+        private Border ShowPrintOverlay(out TextBlock status)
+        {
+            var ring = new System.Windows.Shapes.Ellipse
+            {
+                Width = 40, Height = 40, StrokeThickness = 3,
+                Stroke = R("TextSecondary"),
+                StrokeDashArray = [24, 200],
+                StrokeDashCap = PenLineCap.Round,
+                RenderTransformOrigin = new Point(0.5, 0.5)
+            };
+            var rot = new RotateTransform();
+            ring.RenderTransform = rot;
+            rot.BeginAnimation(RotateTransform.AngleProperty,
+                new System.Windows.Media.Animation.DoubleAnimation(0, 360, new Duration(TimeSpan.FromSeconds(0.9)))
+                { RepeatBehavior = System.Windows.Media.Animation.RepeatBehavior.Forever });
+
+            status = new TextBlock
+            {
+                Text                = "Preparing to print…",
+                Foreground          = R("TextPrimary"),
+                FontSize            = 13,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin              = new Thickness(0, 14, 0, 0)
+            };
+
+            var stack = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+            stack.Children.Add(ring);
+            stack.Children.Add(status);
+
+            // Veil in the card's own colour at high opacity, so the scrim reads on either theme.
+            var veil = R("BgSidebar").Color;
+            var overlay = new Border
+            {
+                Background = new SolidColorBrush(Color.FromArgb(232, veil.R, veil.G, veil.B)),
+                Child      = stack
+            };
+            Panel.SetZIndex(overlay, 99);
+            _rootGrid.Children.Add(overlay);
+            return overlay;
+        }
+
+        private void RemoveOverlay(Border overlay) => _rootGrid.Children.Remove(overlay);
 
         // Parses "1-3,5" style ranges into sorted 0-based indices. Blank/invalid = all pages.
         private static List<int> ParseRange(string? text, int count)


### PR DESCRIPTION
Clicking Print in the preview ran the whole job on the UI thread with no
feedback: re-rasterize every selected page at 300 DPI, compose the
FixedDocument, then spool. On any non-trivial document the window stopped
painting (grey / "Not Responding") and then abruptly closed, so it read as
a crash - "click print and nothing happens".

Cover the card with a progress scrim the moment Print is clicked, move the
300 DPI rasterization onto a background thread (the bitmaps are frozen, so
they cross threads safely), and report "Preparing page X of N" as it goes.
The scrim then shows "Sending to printer" for the compose + spool and clears
when the window closes (or on error, before the failure dialog). The Print
button is disabled and the scrim swallows clicks so the job can't be
double-triggered mid-print.