### PR TITLE
Localize hardcoded "Page N" labels in sidebar, outline and grid view

### DIFF
--- a/PageThumbnailVm.cs
+++ b/PageThumbnailVm.cs
@@ -24,7 +24,8 @@ namespace KillerPDF
         private bool         _loadRequested;
 
         public int    PageIndex { get; } = pageIndex;
-        public string Label     => $"Page {PageIndex + 1}";
+        public string Label     => string.Format(
+            Application.Current?.TryFindResource("Str_PageLabel") as string ?? "Page {0}", PageIndex + 1);
 
         private readonly string _filePath = filePath;
         private readonly int    _rotation = ((rotation % 360) + 360) % 360; // degrees: 0, 90, 180, 270

--- a/SettingsPanel.cs
+++ b/SettingsPanel.cs
@@ -501,6 +501,11 @@ namespace KillerPDF
             // The crop bar is built once with Loc() snapshots; rebuild it in the new language if it's showing.
             RebuildCropBarForLocale();
 
+            // Page thumbnails and outline tooltips snapshot Loc() strings when built; rebuild both
+            // lists so their "Page N" labels switch to the new language immediately.
+            RefreshPageList();
+            RefreshOutlines();
+
             // A visible signature popup is built with Loc() too; rebuild it so its section headers and
             // pen labels switch immediately.
             RefreshSignaturePopupLanguage();

--- a/SidebarOutline.cs
+++ b/SidebarOutline.cs
@@ -214,10 +214,10 @@ namespace KillerPDF
                 string title = FixRawUnicodeTitle(outline.Title ?? string.Empty);
                 var item = new TreeViewItem
                 {
-                    Header = string.IsNullOrEmpty(title) ? "(untitled)" : title,
+                    Header = string.IsNullOrEmpty(title) ? Loc("Str_Outline_Untitled") : title,
                     IsExpanded = true,
                     Tag = new OutlineNodeRef(outline, outlines, pageIdx),
-                    ToolTip = pageIdx >= 0 ? $"Page {pageIdx + 1}" : null,
+                    ToolTip = pageIdx >= 0 ? string.Format(Loc("Str_PageLabel"), pageIdx + 1) : null,
                     Style = (Style)FindResource("OutlineItemStyle")
                 };
                 if (outline.Outlines is not null && outline.Outlines.Count > 0)

--- a/Strings/bn.xaml
+++ b/Strings/bn.xaml
@@ -514,6 +514,7 @@
     <sys:String x:Key="Str_Ctx_BmRename">নাম পরিবর্তন করুন</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">মুছে ফেলুন</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">পৃষ্ঠা {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">পৃষ্ঠা {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">এই বুকমার্ক এবং এর {0}টি চাইল্ড বুকমার্ক মুছে ফেলা হবে?</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">উপরে সরান</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">নিচে সরান</sys:String>

--- a/Strings/de-DE.xaml
+++ b/Strings/de-DE.xaml
@@ -520,6 +520,7 @@ Auf eine unterstützte Größe skalieren? Aussehen und Proportionen der Seiten b
     <sys:String x:Key="Str_Ctx_BmRename">Umbenennen</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">Löschen</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">Seite {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">Seite {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">Dieses Lesezeichen und seine {0} Unter-Lesezeichen löschen?</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">Nach oben</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">Nach unten</sys:String>

--- a/Strings/en-US.xaml
+++ b/Strings/en-US.xaml
@@ -59,6 +59,8 @@
     <!-- ── Sidebar tabs ──────────────────────────────────────────────── -->
     <sys:String x:Key="Str_TabPages">PAGES</sys:String>
     <sys:String x:Key="Str_TabOutlines">OUTLINE</sys:String>
+    <sys:String x:Key="Str_PageLabel">Page {0}</sys:String>
+    <sys:String x:Key="Str_Outline_Untitled">(untitled)</sys:String>
 
     <!-- ── Settings panel ───────────────────────────────────────────── -->
     <sys:String x:Key="Str_Settings">Settings</sys:String>

--- a/Strings/es.xaml
+++ b/Strings/es.xaml
@@ -514,6 +514,7 @@ Puede desinstalarla en cualquier momento desde Agregar o quitar programas.</sys:
     <sys:String x:Key="Str_Ctx_BmRename">Cambiar nombre</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">Eliminar</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">Página {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">Página {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">¿Eliminar este marcador y sus {0} marcadores hijos?</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">Subir</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">Bajar</sys:String>

--- a/Strings/fr-FR.xaml
+++ b/Strings/fr-FR.xaml
@@ -532,6 +532,7 @@ Les redimensionner à une taille prise en charge ? Les pages conservent leur app
     <sys:String x:Key="Str_Ctx_BmRename">Renommer</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">Supprimer</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">Page {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">Page {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">Supprimer ce signet et ses {0} signets enfants ?</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">Monter</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">Descendre</sys:String>

--- a/Strings/ja-JP.xaml
+++ b/Strings/ja-JP.xaml
@@ -545,6 +545,7 @@
     <sys:String x:Key="Str_Ctx_BmRename">名前を変更</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">削除</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">ページ {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">ページ {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">このブックマークと {0} 個の子ブックマークを削除しますか？</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">上へ移動</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">下へ移動</sys:String>

--- a/Strings/tr-TR.xaml
+++ b/Strings/tr-TR.xaml
@@ -514,6 +514,7 @@ Desteklenen bir boyuta ölçeklensin mi? Sayfaların görünümü ve oranları k
     <sys:String x:Key="Str_Ctx_BmRename">Yeniden adlandır</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">Sil</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">Sayfa {0}</sys:String>
+    <sys:String x:Key="Str_PageLabel">Sayfa {0}</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">Bu yer imi ve {0} alt yer imi silinsin mi?</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">Yukarı taşı</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">Aşağı taşı</sys:String>

--- a/Strings/zh-CN.xaml
+++ b/Strings/zh-CN.xaml
@@ -518,6 +518,7 @@
     <sys:String x:Key="Str_Ctx_BmRename">重命名</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">删除</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">第 {0} 页</sys:String>
+    <sys:String x:Key="Str_PageLabel">第 {0} 页</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">删除此书签及其 {0} 个子书签？</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">上移</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">下移</sys:String>

--- a/Strings/zh-TW.xaml
+++ b/Strings/zh-TW.xaml
@@ -516,6 +516,7 @@
     <sys:String x:Key="Str_Ctx_BmRename">重新命名</sys:String>
     <sys:String x:Key="Str_Ctx_BmDelete">刪除</sys:String>
     <sys:String x:Key="Str_Bm_DefaultTitle">第 {0} 頁</sys:String>
+    <sys:String x:Key="Str_PageLabel">第 {0} 頁</sys:String>
     <sys:String x:Key="Str_Bm_DeleteKids">刪除此書籤及其 {0} 個子書籤？</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveUp">上移</sys:String>
     <sys:String x:Key="Str_Ctx_BmMoveDown">下移</sys:String>

--- a/Viewport.cs
+++ b/Viewport.cs
@@ -975,7 +975,7 @@ namespace KillerPDF
 
             var overlay = BuildPageOverlay(pi, pageDipW, pageDipH, null);
             overlay.Cursor = CursorForTool(_currentTool);
-            overlay.ToolTip = $"Page {pi + 1}";
+            overlay.ToolTip = string.Format(Loc("Str_PageLabel"), pi + 1);
 
             var pageGrid = new Grid();
             pageGrid.Children.Add(img);


### PR DESCRIPTION
The sidebar page thumbnails, outline tooltips and grid-view page tooltips always showed English "Page 1", "Page 2"... regardless of the UI language - the strings were hardcoded in `PageThumbnailVm.cs`, `SidebarOutline.cs` and `Viewport.cs`.

This PR introduces `Str_PageLabel` (and `Str_Outline_Untitled` for the "(untitled)" outline placeholder), seeds the new key in every existing translation using the wording already approved for `Str_Bm_DefaultTitle`, and rebuilds the page list and outline on locale switch so the labels update immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)