### PR TITLE
Stop EOL normalization corrupting the vendored UTF-16 sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,3 +52,9 @@
 *.pdb       binary
 *.snk       binary
 *.pfx       binary
+
+# Vendored third-party sources: keep byte-identical to upstream, no EOL normalization.
+# Six of the PdfSharpCore files are UTF-16LE, and the explicit "*.cs text eol=crlf" above
+# overrides git's binary detection - checkout then injects CR into UTF-16 and misaligns
+# every code unit after the first newline, so a fresh clone won't compile.
+third_party/** -text


### PR DESCRIPTION
A fresh clone of v1.6.4 fails to build on Windows with ~3,158 `CS1056: Unexpected character` errors across `third_party/PdfSharpCore`.

```
git clone --depth 1 --branch v1.6.4 https://github.com/SteveTheKiller/KillerPDF.git
cd KillerPDF && dotnet build -c Release
```

## Cause

Six of the vendored files are UTF-16LE:

```
third_party/PdfSharpCore/Fonts.OpenType/GlyphDataTable.cs
third_party/PdfSharpCore/Fonts.OpenType/IndexToLocationTable.cs
third_party/PdfSharpCore/Fonts.OpenType/OpenTypeFontface.cs
third_party/PdfSharpCore/Fonts.OpenType/OpenTypeFontTables.cs
third_party/PdfSharpCore/Fonts.OpenType/TableDirectoryEntry.cs
third_party/PdfSharpCore/Pdf.Advanced/PdfCIDFont.cs
```

The existing `*.cs text eol=crlf` rule sets an explicit `text` attribute, which overrides git's binary detection and applies EOL conversion to them.

The conversion is asymmetric, which is why this only bites on checkout:

- A UTF-16LE newline is `0D 00 0A 00`. There is no adjacent `0D 0A`, so the clean filter leaves it alone and the blobs in the repo are intact.
- On smudge, git sees a lone `0A` not preceded by `0D` and prepends one, giving `0D 00 0D 0A 00`. Every code unit after the first newline is misaligned, which is where the CJK-looking garbage in the compiler output comes from.

An existing working tree is never re-smudged, so it keeps building. `.gitattributes` landed in 3f49640 and `third_party/` in v1.6.4, so nothing collided until now.

## Fix

Exclude the vendored tree from normalization:

```
third_party/** -text
```

Vendored sources shouldn't be normalized anyway, so this keeps them byte-identical to upstream PdfSharpCore for future re-vendoring, rather than re-encoding the six files to UTF-8.

Verified on a fresh clone of this branch: 3,158 errors to a clean build.

Anyone with an existing clone also needs the files re-fetched once, since the corrupt copies are already on disk:

```
rm -r third_party && git checkout -- third_party
```
