### PR TITLE
Resolve bookmarks that point at named destinations

### DIFF
--- a/KillerPDF.Tests/KillerPDF.Tests.csproj
+++ b/KillerPDF.Tests/KillerPDF.Tests.csproj
@@ -30,4 +30,8 @@
     <Compile Include="..\Services\SearchService.cs" Link="Services\SearchService.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\third_party\PdfSharpCore\PdfSharpCore.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/KillerPDF.Tests/OutlineDestinationTests.cs
+++ b/KillerPDF.Tests/OutlineDestinationTests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics;
+using PdfSharpCore.Pdf;
+using PdfSharpCore.Pdf.IO;
+using Xunit;
+
+namespace KillerPDF.Tests
+{
+    /// <summary>
+    /// Regression cover for bookmarks whose /Dest is a *named destination* rather than a literal
+    /// array. wkhtmltopdf writes /Dest /__WKANCHOR_n plus a flat catalog /Dests dictionary, and
+    /// since most HTML-to-PDF invoice generators are wkhtmltopdf underneath, that shape is common.
+    /// PdfSharpCore's PdfOutline.Initialize() used to hit Debug.Assert(false, "See what to do when
+    /// this happened.") on it - a modal dialog in Debug, a silently dead bookmark in Release.
+    /// </summary>
+    public class OutlineDestinationTests
+    {
+        const string DestName = "/__WKANCHOR_2";
+
+        /// <summary>
+        /// Debug.Assert writes to a trace listener and shows a modal box - it never throws, so an
+        /// assert regression would HANG this test rather than fail it. Swap in a listener that
+        /// turns Fail into an exception.
+        /// </summary>
+        sealed class ThrowingListener : TraceListener
+        {
+            public override void Write(string? message) { }
+            public override void WriteLine(string? message) { }
+            public override void Fail(string? message) => throw new Xunit.Sdk.XunitException("Debug.Assert fired: " + message);
+            public override void Fail(string? message, string? detail) => throw new Xunit.Sdk.XunitException("Debug.Assert fired: " + message + " | " + detail);
+        }
+
+        [Fact]
+        public void OpenOutlines_NamedDestination_DoesNotAssert()
+        {
+            var dir  = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(dir);
+            var file = System.IO.Path.Combine(dir, "named_dest.pdf");
+
+            var original = new TraceListener[Trace.Listeners.Count];
+            Trace.Listeners.CopyTo(original, 0);
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new ThrowingListener());
+
+            try
+            {
+                WriteNamedDestPdf(file);
+
+                var doc = PdfReader.Open(file, PdfDocumentOpenMode.Modify);
+                var outlines = doc.Outlines;   // threw before the fix
+
+                Assert.Single(outlines);
+                Assert.Equal("Tax Invoice", outlines[0].Title);
+
+                // Guard the fixture itself: if a future PdfSharpCore writer rewrote the name into a
+                // literal array on save, this test would still pass while no longer covering the
+                // regression at all.
+                Assert.IsType<PdfName>(outlines[0].Elements.GetValue("/Dest"));
+            }
+            finally
+            {
+                Trace.Listeners.Clear();
+                Trace.Listeners.AddRange(original);
+                System.IO.Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Builds a one-page PDF with a single bookmark pointing at a named destination.
+        /// ponytail: the /Dests entry holds the destination array DIRECTLY; the invoice that
+        /// surfaced this held it indirectly. Both take the same /Dest-is-a-PdfName branch, which is
+        /// the regression under test. Make it indirect if that path ever breaks on its own.
+        /// </summary>
+        static void WriteNamedDestPdf(string path)
+        {
+            var doc = new PdfDocument();
+            doc.AddPage();
+
+            // [page /XYZ left top zoom] - integer page number, as wkhtmltopdf emits.
+            var dest = new PdfArray(doc,
+                new PdfInteger(0), new PdfName("/XYZ"),
+                new PdfInteger(0), new PdfInteger(800), new PdfInteger(0));
+
+            var dests = new PdfDictionary(doc);
+            dests.Elements[DestName] = dest;
+            doc.Internals.AddObject(dests);
+
+            var root = new PdfDictionary(doc);
+            root.Elements["/Type"] = new PdfName("/Outlines");
+            doc.Internals.AddObject(root);
+
+            var item = new PdfDictionary(doc);
+            item.Elements["/Title"] = new PdfString("Tax Invoice");
+            item.Elements["/Dest"]  = new PdfName(DestName);
+            item.Elements.SetReference("/Parent", root);
+            doc.Internals.AddObject(item);
+
+            root.Elements.SetReference("/First", item);
+            root.Elements.SetReference("/Last",  item);
+
+            doc.Internals.Catalog.Elements.SetReference("/Outlines", root);
+            doc.Internals.Catalog.Elements.SetReference("/Dests",    dests);
+
+            doc.Save(path);
+        }
+    }
+}

--- a/SidebarOutline.cs
+++ b/SidebarOutline.cs
@@ -226,6 +226,14 @@ namespace KillerPDF
             }
         }
 
+        /// <summary>
+        /// PdfSharpCore only fills DestinationPage when the bookmark's /Dest is a literal array.
+        /// Bookmarks pointing at a *named* destination leave it null - wkhtmltopdf writes
+        /// /Dest /__WKANCHOR_n into a flat catalog /Dests dictionary, and since most HTML-to-PDF
+        /// invoice and statement generators are wkhtmltopdf underneath, that path is common.
+        /// Fall back to ResolveDest (Links.cs), which already walks /Dests and the /Names /Dests
+        /// name tree for the link layer.
+        /// </summary>
         private int GetOutlinePageIndex(PdfSharpCore.Pdf.PdfOutline outline)
         {
             if (outline.DestinationPage is PdfSharpCore.Pdf.PdfPage destPage)
@@ -233,7 +241,15 @@ namespace KillerPDF
                 for (int i = 0; i < _doc!.PageCount; i++)
                     if (ReferenceEquals(_doc.Pages[i], destPage)) return i;
             }
-            return -1;
+
+            var dest = outline.Elements.GetValue("/Dest");
+            if (dest is null
+                && outline.Elements.GetValue("/A") is PdfSharpCore.Pdf.PdfDictionary action
+                && action.Elements.GetName("/S") == "/GoTo")
+            {
+                dest = action.Elements.GetValue("/D");
+            }
+            return ResolveDest(dest) ?? -1;
         }
 
         // ============================================================

--- a/third_party/PdfSharpCore/Pdf/PdfOutline.cs
+++ b/third_party/PdfSharpCore/Pdf/PdfOutline.cs
@@ -339,9 +339,20 @@ namespace PdfSharpCore.Pdf
                 {
                     SplitDestinationPage(destArray);
                 }
+                else if (dest is PdfReference destRef && destRef.Value is PdfArray refArray)
+                {
+                    // /Dest held indirectly. Same handling as the inline array.
+                    SplitDestinationPage(refArray);
+                }
                 else
                 {
-                    Debug.Assert(false, "See what to do when this happened.");
+                    // Named destination: /Dest is a name or string that resolves through the
+                    // catalog's /Dests dictionary or /Names /Dests tree, neither of which this
+                    // class can reach. Perfectly legal PDF - wkhtmltopdf (and so most HTML-to-PDF
+                    // invoice generators) emits exactly this. Leave DestinationPage null and let
+                    // the caller resolve the name.
+                    // Was Debug.Assert(false), which popped a modal assert dialog on every such
+                    // document in Debug builds and silently produced a dead bookmark in Release.
                 }
             }
             else if (a != null)
@@ -372,7 +383,9 @@ namespace PdfSharpCore.Pdf
                 }
                 else
                 {
-                    Debug.Assert(false, "See what to do when this happened.");
+                    // An action that isn't /GoTo (/URI, /GoToR, /Launch, /Named, ...). Legal on an
+                    // outline item - there is just no page in this document to point at, so leave
+                    // DestinationPage null. Was Debug.Assert(false).
                 }
             }
             else


### PR DESCRIPTION
Opening a wkhtmltopdf-generated PDF pops a modal `Assertion Failed` dialog in Debug builds, and produces a silently dead bookmark in Release. Most HTML-to-PDF invoice and statement generators are wkhtmltopdf underneath, so this is not rare - it turned up on an ordinary supplier invoice.

Those files write the destination as a name (`/Dest /__WKANCHOR_n`) resolved through a flat catalog `/Dests` dictionary. `PdfOutline.Initialize()` only handled `/Dest` as a literal array and fell into `Debug.Assert(false, "See what to do when this happened.")`. The `try/catch` in `LoadOutlines` can't help - `Debug.Assert` writes to a trace listener and shows a modal box, it never throws.

### Changes

- **`PdfOutline.Initialize`** - both `Debug.Assert(false)` calls are now documented no-ops, leaving `DestinationPage` null for the caller to resolve. The second one fired on any outline whose action isn't `/GoTo` (`/URI`, `/GoToR`, `/Launch`), which is equally legal PDF. Also derefs `/Dest` when it's held indirectly.
- **`GetOutlinePageIndex`** - falls back to `ResolveDest`, which already walks `/Dests` and the `/Names /Dests` name tree for the link layer. No new resolution logic was written.

`DestinationPage` stays null on these documents by design: PdfSharpCore has no catalog access at that point, so the name lookup lives in KillerPDF where it's testable.

### Tests

Adds `KillerPDF.Tests/OutlineDestinationTests.cs`, which builds a named-destination fixture at runtime rather than committing a binary (`.gitattributes` has no `*.pdf binary` rule, so a committed fixture would be at risk of EOL normalization).

The test installs a `TraceListener` that turns `Debug.Assert` into an exception - without it an assert regression would *hang* the run rather than fail it. It also asserts the fixture's `/Dest` is still a `PdfName` after the save round-trip, so the test can't silently stop covering the regression.

This required adding a `ProjectReference` from `KillerPDF.Tests` to `PdfSharpCore` - the test project previously had none.

Confirmed failing without the fix and passing with it. Full suite: 10/10.

### Verification

| Check | Result |
|---|---|
| Real wkhtmltopdf invoice, before fix | assert fires, outline load aborts |
| Same invoice, after fix | no assert; bookmark resolves to its page |
| 47-page `KillerPDF.pdf` (literal array destinations) | all 7 roots + children resolve unchanged |

No CHANGELOG entry - the file has no `[Unreleased]` section and entries land with a version bump, so that seemed yours to make at release time.
