### PR TITLE
Fix crash when burning a multi-line text annotation

### DIFF
--- a/Annotations.cs
+++ b/Annotations.cs
@@ -2660,7 +2660,17 @@ namespace KillerPDF
                             var layoutRect = new XRect(tboxX + padX, tboxY + padY,
                                                        Math.Max(1, tboxW - 2 * padX), Math.Max(1, tboxH));
                             var tf = new PdfSharpCore.Drawing.Layout.XTextFormatter(gfx);
-                            tf.DrawString(ta.Content, font, taBrush, layoutRect);
+                            // Align explicitly. The shorter DrawString overload hardcodes Justify,
+                            // which the on-screen TextBlock never does (it sets no TextAlignment,
+                            // so WPF gives it Left), so burned text silently rendered differently
+                            // from the editor once a line wrapped. TextFormatAlignment's own
+                            // defaults are Left/Top, which is what we want - state Horizontal
+                            // anyway so a future default change can't quietly undo this.
+                            tf.DrawString(ta.Content, font, taBrush, layoutRect,
+                                new PdfSharpCore.Drawing.Layout.TextFormatAlignment
+                                {
+                                    Horizontal = PdfSharpCore.Drawing.Layout.XParagraphAlignment.Left
+                                });
                             break;
                         }
 

--- a/KillerPDF.Tests/KillerPDF.Tests.csproj
+++ b/KillerPDF.Tests/KillerPDF.Tests.csproj
@@ -30,4 +30,8 @@
     <Compile Include="..\Services\SearchService.cs" Link="Services\SearchService.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\third_party\PdfSharpCore\PdfSharpCore.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/KillerPDF.Tests/TextFormatterTests.cs
+++ b/KillerPDF.Tests/TextFormatterTests.cs
@@ -1,0 +1,69 @@
+using PdfSharpCore.Drawing;
+using PdfSharpCore.Drawing.Layout;
+using PdfSharpCore.Pdf;
+using Xunit;
+
+namespace KillerPDF.Tests
+{
+    /// <summary>
+    /// Regression cover for burning multi-line text annotations into a document (#142).
+    /// CreateBlocks emits a Block(BlockType.LineBreak) per newline, and that constructor never sets
+    /// Text. CreateLayout then skips assigning those blocks a Location, so they keep XPoint(0,0) and
+    /// GetLines' GroupBy lumps them in with the first line. The Justify branch of DrawString called
+    /// block.Text.Trim() on them and threw NullReferenceException.
+    /// Only the Justify path was affected - the other alignments join blocks with string.Join, which
+    /// tolerates nulls. The short DrawString overload defaults to Justify, so KillerPDF hit it.
+    /// </summary>
+    public class TextFormatterTests
+    {
+        static void Draw(string content, TextFormatAlignment alignment = null)
+        {
+            var doc  = new PdfDocument();
+            var page = doc.AddPage();
+            var gfx  = XGraphics.FromPdfPage(page);
+            var font = new XFont("Segoe UI", 12, XFontStyle.Regular);
+            var rect = new XRect(20, 20, 300, 200);
+            var tf   = new XTextFormatter(gfx);
+
+            if (alignment == null)
+                tf.DrawString(content, font, XBrushes.Black, rect);
+            else
+                tf.DrawString(content, font, XBrushes.Black, rect, alignment);
+        }
+
+        [Fact]
+        public void DrawString_SingleLine_DoesNotThrow()
+        {
+            Draw("Hello world");
+        }
+
+        [Fact]
+        public void DrawString_MultiLine_DoesNotThrow()
+        {
+            // The short overload defaults to Justify - this is the exact call KillerPDF makes when
+            // burning a text annotation, and the one that crashed.
+            Draw("Hello\nworld");
+        }
+
+        [Fact]
+        public void DrawString_MultiLineCrLf_DoesNotThrow()
+        {
+            Draw("Hello\r\nworld");
+        }
+
+        [Fact]
+        public void DrawString_MultiLineLeftAligned_DoesNotThrow()
+        {
+            // What the annotation burn now passes explicitly, matching the on-screen TextBlock.
+            Draw("Hello\nworld", new TextFormatAlignment { Horizontal = XParagraphAlignment.Left });
+        }
+
+        [Fact]
+        public void DrawString_ConsecutiveNewlines_DoesNotThrow()
+        {
+            // A blank line produces two adjacent LineBreak blocks, so the line group is entirely
+            // non-drawable. Guards the empty-after-filter path.
+            Draw("Hello\n\n\nworld");
+        }
+    }
+}

--- a/third_party/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
+++ b/third_party/PdfSharpCore/Drawing.Layout/XTextFormatter.cs
@@ -224,11 +224,23 @@ namespace PdfSharpCore.Drawing.Layout
                 var lineBlocks = line as Block[] ?? line.ToArray();
                 if (Alignment == XParagraphAlignment.Justify)
                 {
+                    // LineBreak blocks carry no text (the Block(BlockType) ctor never sets Text) and
+                    // CreateLayout never assigns them a Location, so they keep XPoint(0,0) and
+                    // GetLines' GroupBy lumps them in with the first line. Drawing one dereferenced
+                    // null and threw. They have nothing to render - skip them.
+                    var drawable = lineBlocks.Where(b => b.Type != BlockType.LineBreak && b.Text != null).ToArray();
+                    if (drawable.Length == 0)
+                        continue;
+
                     var locationX = dx;
-                    var gapSize = (layoutRectangle.Width - lineBlocks.Select(l => l.Width).Sum())/ (lineBlocks.Count() - 1);
-                    foreach (var block in lineBlocks)
+                    // A single-block line has no gaps to distribute; dividing by zero here yielded
+                    // Infinity and pushed every following block off the page.
+                    var gapSize = drawable.Length > 1
+                        ? (layoutRectangle.Width - drawable.Select(l => l.Width).Sum()) / (drawable.Length - 1)
+                        : 0;
+                    foreach (var block in drawable)
                     {
-                        _gfx.DrawString(block.Text.Trim(), font, brush, locationX, dy + lineBlocks.First().Location.Y, XStringFormats.TopLeft);
+                        _gfx.DrawString(block.Text.Trim(), font, brush, locationX, dy + drawable.First().Location.Y, XStringFormats.TopLeft);
                         locationX += block.Width + gapSize;
                     }
                 }


### PR DESCRIPTION
Fixes #142.

Placing a text annotation that contains a newline and then triggering a burn (the stamp tool shortcut, via `BurnPageAnnotationsToTemp`) crashes with `NullReferenceException`. Reproduces every time; single-line annotations are fine.

### Two causes

**1. The burn silently justifies.** `Annotations.cs` calls the short `XTextFormatter.DrawString` overload, which hardcodes the alignment:

```csharp
// XTextFormatter.cs:142-148
DrawString(text, font, brush, layoutRectangle, new TextFormatAlignment()
{
    Horizontal = XParagraphAlignment.Justify, Vertical = XVerticalAlignment.Top
}, lineHeight);
```

So every burned annotation takes the justify path, even though the on-screen `TextBlock` sets no `TextAlignment` and therefore renders **Left**. That is a silent WYSIWYG bug in its own right - burned text came out justified while the editor showed it left-aligned, visible as soon as a line wraps. `Annotations.cs` now states the alignment explicitly.

**2. The justify path dereferences null.** `CreateBlocks` emits a `Block(BlockType.LineBreak)` per newline, and that constructor never sets `Text`. `CreateLayout` then skips assigning those blocks a `Location`, so they keep `XPoint(0,0)` and `GetLines`' `GroupBy(b => b.Location.Y)` lumps them into the *first* line. The justify loop calls `block.Text.Trim()` on them and throws.

The other alignments were never affected because they join blocks with `string.Join(" ", ...)`, which tolerates nulls. That is exactly why only this call path crashed.

Line-break blocks are now filtered out before drawing.

### Also fixed

`gapSize` divided by `lineBlocks.Count() - 1`, which is zero on a single-block line. Doubles don't throw, so it produced `Infinity` and pushed every following block off the page rather than crashing. Now guarded.

### Tests

Adds `KillerPDF.Tests/TextFormatterTests.cs` covering single-line, `\n`, `\r\n`, consecutive newlines, and the explicit left-aligned path.

The three multi-line cases fail without the `XTextFormatter` change and pass with it. Worth noting the left-aligned case passes either way - the two fixes each independently stop the crash, which is deliberate: the `Annotations.cs` change fixes KillerPDF, and the `XTextFormatter` change protects anyone who genuinely wants justified text.

Full suite: 14/14.

### Note on #143

This branch is cut from `main`, independent of #143, and the two can merge in either order. They touch different files apart from `KillerPDF.Tests.csproj`, where both add the same `ProjectReference` to PdfSharpCore (the test project previously had none). I verified with `git merge-tree` that they merge cleanly and the reference appears exactly once, not duplicated.
