### PR TITLE
Reset zoom to a true 100% in every view mode

### DIFF
--- a/KeyboardShortcuts.cs
+++ b/KeyboardShortcuts.cs
@@ -326,7 +326,7 @@ namespace KillerPDF
             else if (e.Key == Key.D1 && Keyboard.Modifiers == ModifierKeys.Control && _doc is not null)
             {
                 _fitMode = FitMode.None;
-                SetZoom(1.0);        // actual size (Acrobat Ctrl+1); Ctrl+0 stays the 100% reset
+                SetTrueZoom(1.0);    // actual size (Acrobat Ctrl+1); Ctrl+0 stays the 100% reset
                 e.Handled = true;
             }
             else if (e.Key == Key.D2 && Keyboard.Modifiers == ModifierKeys.Control && _doc is not null)
@@ -414,7 +414,7 @@ namespace KillerPDF
             }
             else if (e.Key == Key.D0 && Keyboard.Modifiers == ModifierKeys.Control)
             {
-                SetZoom(1.0);
+                SetTrueZoom(1.0);
                 e.Handled = true;
             }
             else if (e.Key == Key.Escape && _doc is not null && _currentTool != EditTool.Select)

--- a/Viewport.cs
+++ b/Viewport.cs
@@ -1217,7 +1217,7 @@ namespace KillerPDF
             _rerenderTimer.Start();
         }
 
-        private void ResetZoom() => SetZoom(1.0);
+        private void ResetZoom() => SetTrueZoom(1.0);
 
         // On-screen pixel gap between grid tiles, so adjacent pages don't visually merge - the
         // document pane background shows through it. Tile margins live inside the zoom transform,
@@ -1294,6 +1294,20 @@ namespace KillerPDF
             SyncZoomBox();
             if (_doc != null && PageList.SelectedIndex >= 0)
                 SetStatus(string.Format(Loc("Str_PageOf"), PageList.SelectedIndex + 1, _doc.PageCount) + $" - {DisplayZoomPct():F0}%");
+        }
+
+        /// <summary>
+        /// Zoom entry point for callers that work in TRUE zoom (1.0 = the 100% the user sees),
+        /// as opposed to <see cref="SetZoom"/>, which takes the internal render-dim scale.
+        /// Converts through <see cref="DisplayZoomFactor"/> so an absolute zoom lands on the same
+        /// percentage in every view mode instead of ~182% outside Continuous. The zoom dropdown
+        /// already does this same conversion inline for its presets.
+        /// </summary>
+        private void SetTrueZoom(double trueZoom)
+        {
+            double zf = DisplayZoomFactor();
+            if (zf <= 0) zf = 1.0;
+            SetZoom(trueZoom / zf);
         }
 
         private void ZoomIn_Click(object sender, RoutedEventArgs e)  { if (_viewMode == ViewMode.Grid) GridZoomStep(false); else SetZoom(_zoomLevel + ZoomStep); }


### PR DESCRIPTION
Fixes #152.

**Cause**

`Ctrl+0` and `Ctrl+1` call `SetZoom(1.0)`, which sets the internal `_zoomLevel`. In Continuous that already reads as true zoom, but in Single/Two-Page/Grid the layout box is the render-dim bitmap, so what's displayed is `_zoomLevel * DisplayZoomFactor()`.

Since `_renderDims` maps the page's longest side to 2048 DIP, that factor reduces to `1536 / longest-side-in-points` - 1.82 for A4, 1.94 for Letter. Hence 182% on an A4 page. The factor is aspect-only, so it varies by page size rather than by machine or window - which would make the 226% in the report a different-sized document rather than the second PC.

**Fix**

Adds `SetTrueZoom()`, which converts true zoom to the internal scale through `DisplayZoomFactor()` - the same conversion the zoom dropdown already does inline for its presets - and routes `Ctrl+0` and `Ctrl+1` through it. `SetZoom()` is unchanged, so the zoom in/out, grid-column and fit callers keep passing internal-space values.

Notes:
- `Ctrl+1` (actual size) had the same bug; it isn't mentioned in the issue.
- In Grid, `Ctrl+0` now behaves like the dropdown presets already do: it sets an absolute zoom without updating `_gridColumns`, so the next Ctrl+scroll snaps back to a column fit. Kept that way for consistency rather than widening the diff.
- `ResetZoom()` updated to match; it currently has no callers.

**Testing**

Built on v1.6.6, A4 test file, all four view modes:

| Mode | before | after |
|---|---|---|
| Continuous | 100% | 100% |
| Single Page | 182% | 100% |
| Two Page | 182% | 100% |
| Grid | 182% | 100% |

Same for `Ctrl+1`. Result is independent of window size; zoom in/out, fit modes and dropdown presets unchanged. Letter's 194% is derived, not measured. Test suite passes (15/15).
