### PR TITLE
Detect the edited line's font size from PointSize, not FontSize

### DIFF
--- a/KillerPDF.Tests/PdfTextSizeTests.cs
+++ b/KillerPDF.Tests/PdfTextSizeTests.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace KillerPDF.Tests
+{
+    /// <summary>
+    /// Pins the PdfPig property that in-place text editing reads its font size from (#163).
+    /// Letter.FontSize is the size as written in the content stream, so a generator that emits
+    /// "/F1 1 Tf" and applies the scale through the text matrix reports 1 no matter how large the
+    /// glyphs actually draw. Detection used that value, which collapsed the replacement text onto
+    /// its lower clamp and read back as 3pt. Letter.PointSize is the size in points and is right
+    /// for both spellings, so these tests fail if a PdfPig upgrade changes either meaning.
+    /// </summary>
+    public class PdfTextSizeTests
+    {
+        // Two runs that draw at the same visual size: the first sized by Tf with an identity text
+        // matrix, the second sized entirely by a 12x text matrix.
+        const string Content =
+            "BT\n/F1 12 Tf\n1 0 0 1 72 700 Tm\n(Conventional) Tj\nET\n" +
+            "BT\n/F1 1 Tf\n12 0 0 12 72 660 Tm\n(Scaled) Tj\nET\n";
+
+        /// <summary>A single-page PDF holding <see cref="Content"/>, built by hand so the two runs
+        /// keep their exact Tf and Tm operands - no library would emit the second one.</summary>
+        static byte[] BuildPdf()
+        {
+            string[] objects =
+            [
+                "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+                "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+                "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] "
+                    + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj\n",
+                $"4 0 obj\n<< /Length {Content.Length} >>\nstream\n{Content}\nendstream\nendobj\n",
+                "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+                    + "/Encoding /WinAnsiEncoding >>\nendobj\n",
+            ];
+
+            var pdf = new StringBuilder("%PDF-1.4\n");
+            var offsets = new int[objects.Length];
+            for (int i = 0; i < objects.Length; i++)
+            {
+                offsets[i] = pdf.Length;
+                pdf.Append(objects[i]);
+            }
+
+            int startXref = pdf.Length;
+            pdf.Append($"xref\n0 {objects.Length + 1}\n0000000000 65535 f \n");
+            foreach (int offset in offsets)
+                pdf.Append($"{offset:D10} 00000 n \n");
+            pdf.Append($"trailer\n<< /Size {objects.Length + 1} /Root 1 0 R >>\n")
+               .Append($"startxref\n{startXref}\n%%EOF\n");
+
+            // The content is pure ASCII, so string length above is also the byte offset.
+            return Encoding.ASCII.GetBytes(pdf.ToString());
+        }
+
+        static (double FontSize, double PointSize) FirstLetterOf(string word)
+        {
+            using var doc = PdfDocument.Open(BuildPdf());
+            var letter = doc.GetPage(1).GetWords().Single(w => w.Text == word).Letters[0];
+            return (letter.FontSize, letter.PointSize);
+        }
+
+        [Fact]
+        public void FontSize_MatchesPoints_OnlyWhenTfCarriesTheScale()
+        {
+            Assert.Equal(12, FirstLetterOf("Conventional").FontSize, 3);
+        }
+
+        [Fact]
+        public void FontSize_ReportsTheRawOperand_WhenTheTextMatrixCarriesTheScale()
+        {
+            // The glyphs draw at 12pt, but Tf said 1. This is the value that produced #163.
+            Assert.Equal(1, FirstLetterOf("Scaled").FontSize, 3);
+        }
+
+        [Fact]
+        public void PointSize_IsTheVisualSize_ForBothSpellings()
+        {
+            Assert.Equal(12, FirstLetterOf("Conventional").PointSize, 3);
+            Assert.Equal(12, FirstLetterOf("Scaled").PointSize, 3);
+        }
+    }
+}

--- a/TextEditing.cs
+++ b/TextEditing.cs
@@ -270,8 +270,15 @@ namespace KillerPDF
                     if (firstWord.Letters.Count > 0)
                     {
                         var letter = firstWord.Letters[0];
-                        double pdfFontPts = letter.FontSize;
-                        canvasFontSize = pdfFontPts * syInv;
+                        // PointSize is the glyph size in points. FontSize is the size as written in the
+                        // content stream, which only matches the point size when the text matrix doesn't
+                        // scale: a generator that emits "/F1 1 Tf" and scales through Tm reports FontSize
+                        // 1, which collapsed the replacement onto the floor below and read back as 3pt
+                        // (#163). Fall back to FontSize, then to the line-height estimate above, since
+                        // PointSize can be 0 on fonts with no usable metrics (e.g. some Type3).
+                        double pdfFontPts = letter.PointSize > 0 ? letter.PointSize : letter.FontSize;
+                        if (pdfFontPts > 0)
+                            canvasFontSize = pdfFontPts * syInv;
 
                         // Try to get font name from letter
                         string? rawFont = null;


### PR DESCRIPTION
Fixes #163.

## The property

`TextEditing.cs` sized the replacement box from the first letter's `FontSize`. PdfPig documents that as:

> Size as defined in the PDF file. This is not equivalent to font size in points but is relative to other font sizes on the page.

`Letter.PointSize` is the one documented as "The size of the font in points". Built a PDF with two runs that draw at the same visual size, one sized by `Tf`, one sized entirely by the text matrix:

| run | `FontSize` | `PointSize` |
| --- | --- | --- |
| `/F1 12 Tf` with `1 0 0 1 72 700 Tm` | 12 | 12 |
| `/F1 1 Tf` with `12 0 0 12 72 660 Tm` | **1** | 12 |

`FontSize` matches the point size only when the text matrix carries no scale, which is why this reproduces on some files and not others.

## Where 3 pt came from

It's the lower clamp, not a scaling error. With `FontSize` at 1:

- `StartCoverTextEdit` gets `Math.Max(1 * syInv * 0.8, 8)`, so the box floors at 8 canvas units
- `_textFontSize = Math.Round(8 / syInv)` converts back
- `_renderDims` maps the longest side to 2048, so `syInv` is `2048 / 842` on A4 and `2048 / 792` on Letter

Both round to **3**, which is what the reported screenshot shows.

## The change

Prefer `PointSize` when it's above 0, falling back to `FontSize` and then the existing line-height estimate, since `PointSize` can come back 0 on fonts with no usable metrics.

A 12pt line now detects as 10pt whether or not the scale sits in the text matrix. That's the same value a conventional PDF already produced, so nothing changes for files that worked before.

## Out of scope

`EditTextSizeCorrection = 0.8` is left alone. It's calibrated by eye and sits downstream of this, so it may want revisiting, but it affects every edit equally and isn't specific to #163.

## Testing

`PdfTextSizeTests` builds the two-run PDF above and pins what PdfPig returns for each, so a later PdfPig bump can't quietly flip the meaning. `dotnet test` passes 18/18, and `dotnet build` on the app is clean apart from the pre-existing Costura/Fody warning.

I've run into this myself, it's just not a part of the app I lean on day to day, so I'd never chased it down. The trace above is from the code and a synthesised PDF rather than the reporter's documents, so it's worth a look against one of theirs if they share it.
