### PR TITLE
Render the re-sharpen pass at device resolution, not twice it

### DIFF
--- a/Controls/Viewer/PdfViewer.Viewport.cs
+++ b/Controls/Viewer/PdfViewer.Viewport.cs
@@ -601,7 +601,11 @@ namespace KillerPDF.Controls
             int baseW = Math.Max(800, Math.Min(2048, (int)(targetW * 2)));
             var dpiInfo = VisualTreeHelper.GetDpi(this);
             double dpiScale = Math.Max(dpiInfo.DpiScaleX, dpiInfo.DpiScaleY);
-            int hiW = (int)Math.Min(4096, targetW * 2 * dpiScale * Math.Max(1.0, _zoomLevel));
+            // #189: targetW * zoom * dpiScale already IS the page's on-screen size in device pixels,
+            // so the extra * 2 here was a 2x linear supersample on top of an already-correct budget -
+            // 4x the pixels and 4x the bytes for detail the display cannot resolve. Render at the
+            // size we actually draw at.
+            int hiW = (int)Math.Min(4096, targetW * dpiScale * Math.Max(1.0, _zoomLevel));
 
             // Visible slot range. Slot space is zoom-independent (the LayoutTransform supplies the
             // zoom), so divide the scroll offsets back down - same mapping ScrollChanged uses.
@@ -621,8 +625,12 @@ namespace KillerPDF.Controls
                 if (visible[^1] < _continuousTops.Count - 1) visible.Add(visible[^1] + 1);
             }
 
-            // Below ~1.25x the base budget the re-raster isn't visibly sharper; restore-only pass.
-            bool wantHi = hiW >= (int)(baseW * 1.25);
+            // hiW is now a true device-pixel width, so the trigger is simply "has the base render
+            // run out of pixels for the size we are drawing it at". The old 1.25x margin was
+            // calibrated against a hiW that was inflated 2x; without moving it the pass would stop
+            // firing where it is still needed and pages would be upscaled from the base render.
+            // 1.05 is hysteresis only, so a page sitting on the boundary doesn't re-raster on a nudge.
+            bool wantHi = hiW >= (int)(baseW * 1.05);
 
             _continuousSharpenCts?.Cancel();
             _continuousSharpenCts = new System.Threading.CancellationTokenSource();

--- a/Controls/Viewer/PdfViewer.Viewport.cs
+++ b/Controls/Viewer/PdfViewer.Viewport.cs
@@ -1340,6 +1340,20 @@ namespace KillerPDF.Controls
             _rerenderTimer.Start();
         }
 
+        // #189: the re-sharpen budget is measured in DEVICE pixels, so moving the window to a
+        // monitor at a different scale factor changes how many pixels the page needs without
+        // changing its size in DIPs. In a fit mode the monitor move also changes the window's DIP
+        // size, so the resize path re-fits and re-renders; at a manual zoom (FitMode.None) nothing
+        // else fires, and the page would sit upscaled from the old monitor's render. Queue the same
+        // debounced pass the zoom and resize settles use.
+        // This mattered less while hiW carried a 2x supersample, which happened to cover a
+        // 100% -> 200% jump; at a device-native budget there is no such headroom.
+        protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
+        {
+            base.OnDpiChanged(oldDpi, newDpi);
+            if (_doc is not null) StartRerenderTimer();
+        }
+
         private void ResetZoom() => SetTrueZoom(1.0);
 
         // On-screen pixel gap between grid tiles, so adjacent pages don't visually merge - the


### PR DESCRIPTION
Addresses the memory half of #189.

`ResharpenContinuousVisible` sized its render budget as `hiW = targetW * 2 * dpiScale * zoom`. But `targetW * zoom * dpiScale` is already the page's on-screen width in device pixels, so the `* 2` was a 2x linear supersample on top of a budget that was already correct: 4x the pixels, and 4x the bytes, for detail the display cannot resolve.

Since fit-width zoom is `viewportW / targetW`, `targetW` cancels and `hiW` reduces to twice the viewport width. That is why the cost tracks window size and display resolution rather than anything about the file, and is probably why experiences differ so much in that thread.

### Measured

Instrumented build logging every allocation in `BuildScaledBitmap`. 108-page Letter manual, 247% zoom, maximised on 3840x2160 at 100% scaling:

| | before | after |
|---|---|---|
| peak hi-res bitmap | 80.4 MB/page | 20.1 MB/page |
| hi-res total | 1978 MB | 175 MB |
| total allocated | 2384 MB | 582 MB |
| working set | 834 MB | 674 MB |

At fit-width the same document goes from 508 MB to 318 MB.

**Where the win actually lands.** At fit-width maximised on a 4K screen, stock already wants `hiW` of ~7400 and gets clamped to 4096, so it is running near device-native there anyway and this changes little (588 vs 675 MB). The large numbers above come from the mid-range: moderate zoom on windows that never reach the 4096 clamp. I would rather say that than quote only the best case.

### Two changes, and they have to move together

`wantHi` compared `hiW` against `baseW * 1.25`, a margin calibrated against the inflated `hiW`. Left alone, the pass stops firing where it is still needed and pages get upscaled from the 1632px base render instead. I measured that mistake before catching it. 1.05 keeps only the hysteresis that stops a page on the boundary re-rasterising on every nudge.

The second commit adds a `DpiChanged` override. Nothing subscribed to it anywhere in the viewer. In a fit mode a monitor move also changes the window's DIP size, so the resize path re-fits and re-renders; at a manual zoom nothing fires and the page sits upscaled from the old monitor's render. That was survivable while `hiW` carried the 2x supersample, which happened to cover a 100% -> 200% jump. At a device-native budget there is no headroom left, so it ships with the change rather than after it. I know this is a second thing in one PR; shipping the first without it seemed worse.

### Verified

- Resize small window to maximised, fit-width: re-renders at 3604px, matching the new device width. Confirmed by instrumented log, before and after.
- Fit-page maximised produces no re-render, correctly: a portrait page on this screen is height-bound at ~1546px, still inside the 1632px base render.
- Sharpness: aligned body-text crops differ by 2.6/255 mean, 8.3% of pixels by more than 8/255, entirely on glyph-edge antialiasing. Nothing changes shape, weight or position.

**Not verified:** the DPI path itself. This machine is a single monitor at 96 DPI, so I could not exercise a real scale-factor change. The override compiles against the actual virtual and mirrors the existing settle paths, but it is reasoned rather than observed, and worth a look on mixed-DPI hardware.

If you would rather keep some supersample, the factor is a one-character change; 1.25 measured 31.4 MB/page and 1.5 measured 45.2 MB/page.

Not addressed here: the base render cache is the other half of #189 (48 pages x 13.1 MB for Letter = 629 MB at the cap). Separate question, left alone.
