### PR TITLE
Centre the picker radio's selected dot in its ring

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1025,7 +1025,11 @@
                                     <Ellipse x:Name="ring" Width="14" Height="14"
                                              Stroke="{DynamicResource DimTextBrush}" StrokeThickness="1.5"
                                              Fill="Transparent"/>
-                                    <Ellipse x:Name="dot" Width="7" Height="7"
+                                    <!-- EVEN size, like the ring: both are centred in the 16px Grid, so an
+                                         odd width lands the dot on a half-pixel offset ((16-7)/2 = 4.5) while
+                                         the ring sits on a clean 1. That put the dot half a pixel off-centre
+                                         inside its own ring. 8 gives an offset of 4. -->
+                                    <Ellipse x:Name="dot" Width="8" Height="8"
                                              Fill="{DynamicResource RadioAccent}" Visibility="Collapsed"/>
                                 </Grid>
                                 <ContentPresenter VerticalAlignment="Center"/>


### PR DESCRIPTION
The `ThemeRadio` template's inner dot is a 7px `Ellipse` centred in a 16px `Grid`, so its layout offset is `(16-7)/2 = 4.5` - half a pixel. The 14px ring around it is even, so it lands on a clean offset of 1. The dot therefore sits half a pixel off-centre inside its own ring, which reads as a slightly lopsided selection mark.

`Width`/`Height` 7 -> 8 gives an offset of 4. No other geometry changes; the 14px ring at 1.5 stroke still leaves clearance all round.

`ThemeRadio` is shared by the theme, language and view flyouts, so this is one change for all three.

<img width="314" height="265" alt="image" src="https://github.com/user-attachments/assets/fc5ebe40-d9db-41c4-b441-d40cb539a073" />

Built and checked in the running app across all six themes.