### PR TITLE
Centre the accent swatch in its strip

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2375,7 +2375,7 @@
                                      Height="Auto" clears the AccentDot style's fixed 18 so the rows
                                      size them; the 9px radius caps the 18px width into capsule ends
                                      (98SE's 0 keeps them square). -->
-                                <Grid x:Name="AccentStrip" Margin="10,6,2,6">
+                                <Grid x:Name="AccentStrip" Margin="15,6,0,6">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="*"/>
                                         <RowDefinition Height="*"/>

--- a/Shell/SettingsPanel.cs
+++ b/Shell/SettingsPanel.cs
@@ -389,7 +389,7 @@ namespace KillerPDF
 
         private Theme _stripFamily = Theme.Dark;   // the family the strip's dots currently show
         private bool  _stripOpen;
-        private const double AccentStripWidth   = 39;    // 1px rule + 10 gap + 26 swatch + 2 air
+        private const double AccentStripWidth   = 41;    // 1px rule + 14 gap + 26 swatch, centring it against the card's 14 right margin
         private const double AccentStripSlideMs = 180;
 
         private Border[] StripDots =>


### PR DESCRIPTION
Follow-up to #199, off the comment there.

The strip host is 39 wide, as your own note says: 1px rule + 10 gap + 26 swatch + 2 air. The flyout card's grid margin is 12 left against 14 right. So the swatch sits about 10 from the rule and about 16 from the card's inner edge, roughly 3.5 left of centre, which reads as the column being off.

`AccentStripWidth` 39 -> 41 and the `AccentStrip` margin `10,6,2,6` -> `15,6,0,6` puts it at 14 and 14.
<img width="204" height="452" alt="image" src="https://github.com/user-attachments/assets/304d2128-6190-4c9b-b60b-02e58fab9cd0" />


Two things I deliberately did not touch:

- The card's `12,10,14,10` margin. The view and language flyouts use the identical value (MainWindow.xaml 1988 and 2124), so evening it up there would leave the theme card inconsistent with its siblings.
- The placement behaviour. The extra 2px of width runs rightward from the pinned left edge into the document side, so the card does not move, which is the property the strip design relies on.

Built and checked in the running app on the accented themes.