### PR TITLE
Opt out of PolySharp's generated EmbeddedAttribute

### DIFF
--- a/KillerPDF.Tests/KillerPDF.Tests.csproj
+++ b/KillerPDF.Tests/KillerPDF.Tests.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- Inert on PolySharp 1.15.0, whose targets never make this property compiler-visible.
+         Set here so bumping this project to 1.16.0 cannot reintroduce the CS8336 reserved-name
+         break on net48 that KillerPDF.csproj works around. -->
+    <PolySharpUseEmbeddedAttributeForGeneratedTypes>false</PolySharpUseEmbeddedAttributeForGeneratedTypes>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>

--- a/KillerPDF.csproj
+++ b/KillerPDF.csproj
@@ -6,6 +6,9 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- PolySharp 1.16.0 generates Microsoft.CodeAnalysis.EmbeddedAttribute by default; the
+         compiler reserves that name (CS8336). Opt back out to keep net48 building. -->
+    <PolySharpUseEmbeddedAttributeForGeneratedTypes>false</PolySharpUseEmbeddedAttributeForGeneratedTypes>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\kp-icon.ico</ApplicationIcon>


### PR DESCRIPTION
`main` doesn't build for me as of `6582c76`:

```
error CS8336: The type name 'Microsoft.CodeAnalysis.EmbeddedAttribute' is reserved to be used by the compiler.
```

The PolySharp bump to 1.16.0 in `58447d7` is the cause.
1.16.0 started generating `Microsoft.CodeAnalysis.EmbeddedAttribute` by default, the compiler reserves that name, and so the generated polyfill file fails to compile.

The same release added a property to turn that generation back off, so the fix is one line in `KillerPDF.csproj` with no code change:

```xml
<PolySharpUseEmbeddedAttributeForGeneratedTypes>false</PolySharpUseEmbeddedAttributeForGeneratedTypes>
```

That property is the only difference between the 1.15.0 and 1.16.0 MSBuild targets, so setting it to `false` gets 1.15.0's behaviour while keeping the newer package.

Checked on .NET SDK 8.0.422: a clean checkout of `6582c76` fails.
Either pinning PolySharp back to 1.15.0 or setting this property builds clean, with 44/44 tests passing.

The second commit sets the same property in `KillerPDF.Tests.csproj`.
That project stays on PolySharp 1.15.0, whose targets never mention the attribute, so it is a no-op today and only bites if that reference is ever moved to 1.16.0.
Two one-line properties rather than a root `Directory.Build.props`, since a props file at the root would also be inherited by the vendored `third_party/PdfSharpCore` and by the `Packaging/KillerLauncher` that `build/build-portable.ps1` publishes, which is a much wider blast radius than the one property it would replace.

I have only tried the one SDK, so it might not reproduce on yours.
If it doesn't, the property is a no-op for you and this is still safe to take.
