### PR TITLE
Reserve the print options scrollbar, unbox the combo and picker chevrons

### DIFF
--- a/Controls/PickerStyles.xaml
+++ b/Controls/PickerStyles.xaml
@@ -693,8 +693,17 @@
                                            VerticalAlignment="Center"
                                            HorizontalAlignment="Center"
                                            IsHitTestVisible="False"/>
+                                <!-- Chevron face keys off ComboButtonBrush, the same key the
+                                     MainWindow copy uses. ChipFaceBrush is defined by 98SE alone
+                                     and CompleteAppPalette never materialises it, so it is not a
+                                     key that resolves to nothing elsewhere - it is one that gets
+                                     stuck: ApplyTheme copies the incoming theme in per key and
+                                     removes nothing, so visiting 98SE once left #c0c0c0 in the
+                                     live dictionary and this chevron kept a raised Win98 face on
+                                     every theme after it. ComboButtonBrush is materialised into
+                                     every palette, so the two template copies stay in step. -->
                                 <Border Grid.Column="1" IsHitTestVisible="False"
-                                        Background="{DynamicResource ChipFaceBrush}"
+                                        Background="{DynamicResource ComboButtonBrush}"
                                         BorderBrush="{DynamicResource BevelLightBrush}"
                                         BorderThickness="{DynamicResource ButtonBevelLightThickness}"/>
                                 <Border Grid.Column="1" IsHitTestVisible="False"

--- a/Controls/PrintPreviewWindow.cs
+++ b/Controls/PrintPreviewWindow.cs
@@ -774,7 +774,11 @@ namespace KillerPDF
             var optionsScroller = new ScrollViewer
             {
                 Content                       = panel,
-                VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
+                // Visible, not Auto. The options column is a fixed 260 and the bar is 12 wide (16 on
+                // 98SE), so letting it appear on demand shrinks every control in the panel the moment
+                // a section is expanded past the viewport. Reserving the width costs an idle track and
+                // keeps the fields still.
+                VerticalScrollBarVisibility   = ScrollBarVisibility.Visible,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled
             };
             Grid.SetRow(optionsScroller, 0);

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -859,7 +859,7 @@
                                     <!-- Chevron arrow -->
                                     <Grid Grid.Column="1" Width="{DynamicResource ComboButtonSize}"
                                           Height="{DynamicResource ComboButtonSize}"
-                                          HorizontalAlignment="Right" VerticalAlignment="Center"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"
                                           Margin="0" IsHitTestVisible="False">
                                     <Border x:Name="ComboChevFace" Background="{DynamicResource ComboButtonBrush}"/>
                                     <Border x:Name="ComboChevLight" IsHitTestVisible="False" BorderBrush="{DynamicResource BevelLightBrush}" BorderThickness="{DynamicResource BevelLightThickness}"/>

--- a/Services/ThemeManager.cs
+++ b/Services/ThemeManager.cs
@@ -292,7 +292,10 @@ namespace KillerPDF.Services
                 d["UiFont"] = new FontFamily("Segoe UI, Microsoft JhengHei UI, Nirmala UI");
             Alias("ComboFieldBrush", "PaneBrush");
             Alias("ComboPopupBrush", "PaneBrush");
-            Alias("ComboButtonBrush", "ComboFieldBrush");
+            // The chevron sits directly on the combo field: no button face by default, so the
+            // arrow does not read as a separate boxed control. 98SE sets ComboButtonBrush
+            // explicitly (#c0c0c0) and keeps its raised Win98 drop-down button.
+            if (!d.Contains("ComboButtonBrush")) d["ComboButtonBrush"] = Brushes.Transparent;
             Alias("ComboButtonHoverBrush", "RowHoverBrush");
             // These must be materialized into every completed palette. Theme dictionaries are
             // copied into the live dictionary in place, so a missing key would otherwise retain


### PR DESCRIPTION
Three layout fixes in the print dialog, and the third one turns out to be a theme bug that outlives the dialog: once you select 98SE, every theme after it draws the file picker's chevron in a grey Win98 box for the rest of the session.

Two of the three touch the shared ComboBox template, so they land on every combo in the app and not just this window.

Needs #218 first or it won't build (cut off `6582c76`).
Nothing else blocks it - I test-merged this one, #220 and #222 onto #218 in three different orders and they all apply clean, so take them in whatever order suits.

### Reserve the print options scrollbar

The options column is a fixed 260 wide and the scrollbar is 12 (16 on 98SE).
Under `ScrollBarVisibility.Auto` every control in the panel lost 12px the moment a section was expanded past the viewport, so the whole column reshuffled on a click.
`Visible` reserves the lane up front.

`ScrollArrowSize` and `ScrollTrackBrush` default to `0` and `Transparent`, so an idle bar shows nothing at all.
98SE sets them to 16 and `#dfdfdf`, where the reserved bar reads as an ordinary Win98 scrollbar.

Checked by expanding LAYOUT with the dialog open and diffing the frames: zero differing pixels across the options content, the only change being the thumb appearing in the reserved lane.

<img width="568" height="492" alt="pr-reflow" src="https://github.com/user-attachments/assets/103c8617-6e62-4b69-994e-99debed62f9f" />

### Unbox the combo chevron

The chevron sat in an 18px box right-aligned inside a 22px column, so it had a 4px gap on its left and none on its right, pushed up against the rounded field border.
`ComboButtonBrush` aliased to `ComboFieldBrush`, which painted that box a different shade from the field under it, so the arrow read as a separate boxed control.

`ComboButtonBrush` now defaults to `Transparent` and the chevron sits on the field.
98SE sets it explicitly to `#c0c0c0`, so its raised Win98 drop-down button is unchanged.
Centring the chevron grid is a no-op on 98SE, where `ComboButtonMinWidth` is 16 and the column already equals the box width.

Measured off the rendered dialog: the chevron ink is 8x4 with 7px clear either side, 0px off both the column centre and the field centre.


<img width="424" height="576" alt="pr-chevron" src="https://github.com/user-attachments/assets/c2f583fe-110b-4f5e-9138-ee654d097a0e" />


### Unbox the picker chevron too

`Controls/PickerStyles.xaml` holds a second copy of the combo template and asks for the two to be kept in step, so its chevron face moves to `ComboButtonBrush` as well.

I had this filed as 98SE-only when I first wrote it up, and that was wrong.
`ChipFaceBrush` is defined by 98SE alone and `CompleteAppPalette` never materialises it, while `ApplyTheme` copies each incoming theme in per key and removes nothing.
So selecting 98SE once leaves `#c0c0c0` in the live dictionary, and every theme after it inherits the face.

Reproduced on 1.7.3. Start on Greed, open the file picker, the chevron is flat.
Switch to 98SE, switch back to Greed, open the picker again and it is sitting in a grey raised Win98 box.
It stays there for the rest of the session.
Ran the same five steps on this branch and it stays flat.
<img width="228" height="136" alt="2026-08-21_09-12 - MC Screenshot" src="https://github.com/user-attachments/assets/d732ee3f-39d5-4148-b835-e00daebb7498" />
<img width="228" height="136" alt="2026-08-21_09-12 - MC Screenshot_1" src="https://github.com/user-attachments/assets/0c30878a-5db4-4cb3-98aa-212c7de3d945" />




`ComboButtonBrush` is materialised into every palette, Transparent by default and `#c0c0c0` on 98SE, so it cannot go stale the same way.

### Not covered

`TransformWindow` has the same `Auto` scroller with six collapsible sections, so it reflows the same way. Left out to keep this small, happy to follow up.

---

Separate to the diff: the application's been running noticeably smoother the last few releases.
Just as a heads up, there's a few small cosmetic tweaks I'd like to do.
Nothing that changes how anything operates or performs, just little tidy-ups.
If you'd rather I list these out as issues with a PR attached and ready to go, just let me know.



