### PR TITLE
Stop an unmatched page range printing the whole document

### DIFF
--- a/Controls/PrintPreviewWindow.cs
+++ b/Controls/PrintPreviewWindow.cs
@@ -1072,6 +1072,28 @@ namespace KillerPDF
             if (_pages.Length == 0) { _pageLabel.Text = S("Str_Print_NoPages"); _renderLabel.Visibility = Visibility.Collapsed; return; }
 
             var selected = SelectedIndices();
+            if (selected.Count == 0)
+            {
+                // Reuses the string the print-time guard already shows, so there is nothing new to
+                // translate. The Pages box drives this on every keystroke, so the message appears as
+                // soon as the range stops matching anything.
+                _pageLabel.Text = "";
+                UpdateRenderLabel();
+                _previewHost.Children.Add(new TextBlock
+                {
+                    Text                = S("Str_Dlg_NoValidPages"),
+                    Foreground          = R("MutedTextBrush"),
+                    FontSize            = 12,
+                    Margin              = new Thickness(24),
+                    TextWrapping        = TextWrapping.Wrap,
+                    TextAlignment       = TextAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment   = VerticalAlignment.Center,
+                });
+                if (_printBtn != null) _printBtn.IsEnabled = false;
+                return;
+            }
+            if (_printBtn != null) _printBtn.IsEnabled = !_isLoading;
             int sheets = Math.Max(1, (selected.Count + _nUp - 1) / _nUp);
             int sheet = Math.Max(0, Math.Min(_previewIndex, sheets - 1));
             _previewIndex = sheet;
@@ -1449,7 +1471,11 @@ namespace KillerPDF
                     if (v >= 1 && v <= count) set.Add(v - 1);
                 }
             }
-            return set.Count == 0 ? [.. Enumerable.Range(0, count)] : [.. set];
+            // A blank box already returned every page above, so reaching here with nothing resolved
+            // means the text matched no page - a number past the end, or a typo. Return the empty
+            // set and let the callers surface it. Falling back to every page here meant a slipped
+            // keystroke in the Pages box silently spooled the whole document.
+            return [.. set];
         }
 
         // Shared themed button (UiKit.Make) so the print dialog matches every other dialog.

--- a/Controls/PrintPreviewWindow.cs
+++ b/Controls/PrintPreviewWindow.cs
@@ -35,6 +35,11 @@ namespace KillerPDF
         private int _loadedCount;              // pages rendered so far
         private bool _isLoading = true;        // true until every page has rendered
         private Button _printBtn = null!;      // disabled while pages are still loading
+        // Set while a job is rasterizing and spooling. The print scrim blocks the mouse but takes no
+        // keyboard focus, so a keystroke in the Pages box (or an arrow key in a combo) still re-runs
+        // UpdatePreview mid-job; without this it would re-enable Print and Enter (IsDefault) would
+        // spool a second copy behind the scrim. Only the failure path clears it - success closes.
+        private bool _printing;
         public volatile bool Canceled;        // set on close so the background render stops
 
         private readonly List<PrintQueue> _queues = [];
@@ -322,8 +327,9 @@ namespace KillerPDF
         };
 
         // The page indices the preview walks AND the Print button sends - whatever range is typed in the
-        // Pages box (blank or unparseable falls back to every page, matching ParseRange). Driving the
-        // preview off this keeps it showing exactly the pages that will print (type "6" -> preview page 6).
+        // Pages box (blank = every page; a range that matches no page = empty, which the preview and the
+        // print guard both surface). Driving the preview off this keeps it showing exactly the pages that
+        // will print (type "6" -> preview page 6).
         private List<int> SelectedIndices()
         {
             var list = ParseRange(_pagesBox.Text, _pages.Length);
@@ -1093,7 +1099,7 @@ namespace KillerPDF
                 if (_printBtn != null) _printBtn.IsEnabled = false;
                 return;
             }
-            if (_printBtn != null) _printBtn.IsEnabled = !_isLoading;
+            if (_printBtn != null) _printBtn.IsEnabled = !_isLoading && !_printing;
             int sheets = Math.Max(1, (selected.Count + _nUp - 1) / _nUp);
             int sheet = Math.Max(0, Math.Min(_previewIndex, sheets - 1));
             _previewIndex = sheet;
@@ -1249,6 +1255,7 @@ namespace KillerPDF
             // with a progress scrim, push the heavy rasterization onto a background thread, and only
             // return to the PDF once the job is handed to the spooler.
             var overlay = ShowPrintOverlay(out TextBlock statusText);
+            _printing = true;
             _printBtn.IsEnabled = false;
 
             try
@@ -1389,7 +1396,10 @@ namespace KillerPDF
             catch (Exception ex)
             {
                 RemoveOverlay(overlay);   // drop the scrim so the error dialog isn't stuck behind it
-                _printBtn.IsEnabled = true;
+                _printing = false;
+                // Re-derive Print rather than switching it straight back on: the Pages box could have
+                // been retyped behind the scrim, and a range that now matches nothing must stay disabled.
+                UpdatePreview();
                 KillerDialog.Show(this, $"Print failed:\n{ex.GetType().Name}: {ex.Message}",
                     "KillerPDF", MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -1443,7 +1453,8 @@ namespace KillerPDF
 
         private void RemoveOverlay(Border overlay) => _rootGrid.Children.Remove(overlay);
 
-        // Parses "1-3,5" style ranges into sorted 0-based indices. Blank/invalid = all pages.
+        // Parses "1-3,5" style ranges into sorted 0-based indices. Blank = all pages; a range that
+        // matches no page returns empty and the callers surface it.
         private static List<int> ParseRange(string? text, int count)
         {
             text = text?.Trim() ?? "";


### PR DESCRIPTION
Typing a page number past the end of the document prints the **whole document** instead of nothing.

Needs #218 first or it won't build (cut off `6582c76`).
Independent of #219 and #222 - all three apply clean onto #218 in any order, and #222's bounds clamp composes with this change rather than colliding with it.

Two commits: the fix, then a second one for a bug the first commit introduced (Print stayed live behind the scrim). Detail at the bottom.

`ParseRange` finishes with a fallback to every page when nothing resolved:

```csharp
return set.Count == 0 ? [.. Enumerable.Range(0, count)] : [.. set];
```

Out-of-range values never reach the set, since both branches guard on `1 <= i <= count`. So the set stays empty and the fallback quietly selects everything. Same for a typo, a bare `0`, or a half-finished `1-`.

The empty-selection guard in `DoPrint` that shows `Str_Dlg_NoValidPages` never fires, because the list is never empty by the time it is reached.

**Before:** `99` typed on a 50-page document reads "Page 1 of 50" with Print enabled, so it spools all 50 sheets.

A blank box still returns every page from the early return further up, so that is untouched. Reaching the end with nothing resolved now returns the empty set, which the existing `DoPrint` guard already handles.

The preview also says so instead of composing a blank sheet, and holds Print until the range is fixed. It reuses `Str_Dlg_NoValidPages`, the string that guard already shows, so **there is nothing new to translate**. The Pages box already drove the preview on every keystroke, so it reacts as you type.

Checked in the app across four cases:

| Pages box | preview | Print |
|---|---|---|
| blank | all 50 pages | enabled |
| `99` | "No valid pages in that range." | disabled |
| `3-5` | page 3 | enabled |
| cleared again | all 50 pages | enabled |

Clearing the box returns to the exact baseline, so blank-means-all is unchanged.


### Second commit: hold Print disabled while a job is in flight

The first commit introduced a bug and I caught it re-reading my own diff.

That commit made `UpdatePreview` re-derive the Print button's enabled state, and `UpdatePreview` runs on every keystroke in the Pages box.
The scrim over a running job blocks the mouse but takes no keyboard focus, so the Pages box keeps taking keystrokes mid-job.
Print is `IsDefault`.
A keystroke and then Enter would spool a second copy behind the scrim.

A `_printing` flag now holds it disabled.
The failure path clears the flag and re-derives through `UpdatePreview` rather than switching Print straight back on, because the range could have been retyped behind the scrim.

Checked the button in the app across blank, an out-of-range number, cleared again, and a valid range.
The in-flight case I traced through the code rather than staging a printer failure: every exit from `DoPrint` after the flag is set either closes the window or goes through the catch that clears it, and there is no `OnClosing` that could veto the close and strand it.

