### PR TITLE
Stop a huge page range freezing the app

### DIFF
--- a/Controls/PrintPreviewWindow.cs
+++ b/Controls/PrintPreviewWindow.cs
@@ -1440,8 +1440,13 @@ namespace KillerPDF
                         int.TryParse(seg[1].Trim(), out int b))
                     {
                         if (a > b) (a, b) = (b, a);
-                        for (int i = a; i <= b; i++)
-                            if (i >= 1 && i <= count) set.Add(i - 1);
+                        // Clamp the ends rather than testing each i inside the loop. With the test
+                        // inside, "1-2147483647" ran i++ past int.MaxValue, wrapped to int.MinValue,
+                        // and i <= b was true again - the loop never ended. The Pages box drives the
+                        // preview live, so that froze the app on a keystroke. Same output either way.
+                        if (a < 1) a = 1;
+                        if (b > count) b = count;
+                        for (int i = a; i <= b; i++) set.Add(i - 1);
                     }
                 }
                 else if (int.TryParse(part, out int v))

--- a/Controls/StampWindow.cs
+++ b/Controls/StampWindow.cs
@@ -643,7 +643,12 @@ namespace KillerPDF
                 if (dash > 0)
                 {
                     if (int.TryParse(p[..dash].Trim(), out int a) && int.TryParse(p[(dash + 1)..].Trim(), out int b))
-                        for (int i = Math.Min(a, b); i <= Math.Max(a, b); i++) if (i >= 1 && i <= pageCount) set.Add(i - 1);
+                        {
+                            // Clamp the ends rather than testing each i: an unclamped "1-2147483647" wrapped
+                            // i++ to int.MinValue at the top and never terminated. Same fix as ParseRange.
+                            int lo = Math.Max(1, Math.Min(a, b)), hi = Math.Min(pageCount, Math.Max(a, b));
+                            for (int i = lo; i <= hi; i++) set.Add(i - 1);
+                        }
                 }
                 else if (int.TryParse(p, out int single) && single >= 1 && single <= pageCount) set.Add(single - 1);
             }

--- a/Services/PdfBurn.cs
+++ b/Services/PdfBurn.cs
@@ -344,7 +344,12 @@ namespace KillerPDF.Services
                 if (dash > 0)
                 {
                     if (int.TryParse(p[..dash].Trim(), out int a) && int.TryParse(p[(dash + 1)..].Trim(), out int b))
-                        for (int i = Math.Min(a, b); i <= Math.Max(a, b); i++) if (i >= 1 && i <= pageCount) set.Add(i - 1);
+                        {
+                            // Clamp the ends rather than testing each i: an unclamped "1-2147483647" wrapped
+                            // i++ to int.MinValue at the top and never terminated. Same fix as ParseRange.
+                            int lo = Math.Max(1, Math.Min(a, b)), hi = Math.Min(pageCount, Math.Max(a, b));
+                            for (int i = lo; i <= hi; i++) set.Add(i - 1);
+                        }
                 }
                 else if (int.TryParse(p, out int single) && single >= 1 && single <= pageCount) set.Add(single - 1);
             }


### PR DESCRIPTION
Typing `1-2147483647` into the print dialog's Pages box hangs the app.

Needs #218 first or it won't build (cut off `6582c76`).
Independent of #219 and #220 - all three apply clean onto #218 in any order, and this clamp composes with #220's empty-set return rather than colliding with it.

One call for you: the same three lines are copy-pasted across three parsers, so this fixes all three in place.
The version that folds them into one shared parser came to 215 insertions across 7 files against 19 across 3 here, which is a lot of refactor to staple to a hang fix, so it is not in this PR.
Happy to send it separately if you want it.

Three page-range parsers share the same loop shape:

```csharp
for (int i = a; i <= b; i++)
    if (i >= 1 && i <= count) set.Add(i - 1);
```

The bound is never clamped, so `b` can be `int.MaxValue`. C# arithmetic is unchecked, so `i++` wraps to `int.MinValue` at the top, `i <= b` is true again, and the loop never ends.

The Pages box already drives the preview on every keystroke, so it hangs while you are still typing rather than on Print. `StampWindow.ParseRange` and `PdfBurn.StampPageRange` are byte-identical copies, so the same string in a watermark or page-number range takes the same path.

**Reproduced on 1.7.3.** Pasting `2147483647-2147483647` into the Pages box locks the window. Paste rather than type: typing walks through intermediate bounds that each spin for a moment and then finish, so it reads as lag, while the doubled value reaches the wrap on the first iteration and hangs straight away.

Clamping `a` and `b` to the document before the loop ends it. The pages selected do not change: the old code tested `1 <= i <= count` on each `i`, and the clamped bounds are that same interval. A range entirely past the end still selects nothing, because the clamp inverts the bounds and the loop does not run.

The two strict parsers are untouched. `PdfViewer.Crop.ParsePageRange` and `CliRunner.CliParsePageRange` reject the whole input on a bad token, and neither loops on an unclamped bound.

I have only watched the print path hang, not the two stamp copies, but they are byte-identical to each other and take the same input down the same loop.

