### PR TITLE
Fit translated text in the install prompt and the export dialog

### DIFF
--- a/Controls/ExportImagesDialog.cs
+++ b/Controls/ExportImagesDialog.cs
@@ -20,8 +20,10 @@ namespace KillerPDF
         public ExportImagesDialog(Window owner)
         {
             Title = "KillerPDF - " + L("Str_ExportImg_Suffix");
-            Width = 380;
-            SizeToContent = SizeToContent.Height;
+            // Width follows the caption. "Export Pages as Images" is 22 characters in en-US and
+            // up to 35 translated, which ran the title under the close button at a fixed 380 (#223).
+            MinWidth = 380;
+            SizeToContent = SizeToContent.WidthAndHeight;
             UseLayoutRounding = true;
             DialogChrome.Configure(this, owner);
             BuildUi();

--- a/Controls/UiKit.cs
+++ b/Controls/UiKit.cs
@@ -141,7 +141,7 @@ namespace KillerPDF
         // StyleCheckBox/ThemedCheckTemplate copies so every checkbox in the app is identical.
         public static CheckBox CheckBox(string label) => new()
         {
-            Content                  = label,
+            Content                  = new TextBlock { Text = label, TextWrapping = TextWrapping.Wrap },
             Foreground               = Brush("TextBrush"),
             FontFamily               = UiFont,
             FontSize                 = 12,
@@ -152,14 +152,17 @@ namespace KillerPDF
 
         private static ControlTemplate CheckTemplate()
         {
-            var row = new FrameworkElementFactory(typeof(StackPanel)) { Name = "root" };
-            row.SetValue(StackPanel.OrientationProperty, Orientation.Horizontal);
+            // DockPanel, not a horizontal StackPanel. A horizontal StackPanel measures its children
+            // at infinite width, so the label could never wrap however it was configured. Docking the
+            // box to the left leaves the label a real width to wrap inside (#223).
+            var row = new FrameworkElementFactory(typeof(DockPanel)) { Name = "root" };
 
             var boxHost = new FrameworkElementFactory(typeof(Grid));
             boxHost.SetValue(FrameworkElement.WidthProperty, 16.0);
             boxHost.SetValue(FrameworkElement.HeightProperty, 16.0);
             boxHost.SetValue(FrameworkElement.VerticalAlignmentProperty, VerticalAlignment.Center);
             boxHost.SetValue(FrameworkElement.MarginProperty, new Thickness(0, 0, 8, 0));
+            boxHost.SetValue(DockPanel.DockProperty, Dock.Left);
 
             var box = new FrameworkElementFactory(typeof(Border));
             box.SetValue(Border.CornerRadiusProperty, RadControl);


### PR DESCRIPTION
Two dialogs in #223 have text running past the edge, and neither is specific to German.

`Str_Chk_AllUsers` is 51 characters in en-US and 73 in de-DE, 77 in pl-PL, 82 in hu-HU, 84 in fr-FR. French and Polish clip further than the screenshot in the issue does.

The checkbox label could not wrap at any width:

```csharp
var row = new FrameworkElementFactory(typeof(StackPanel)) { Name = "root" };
row.SetValue(StackPanel.OrientationProperty, Orientation.Horizontal);
```

A horizontal `StackPanel` measures its children at infinite width, so the `ContentPresenter` always reports its full single-line width and `TextWrapping` has nothing to act on. Put a wrap on the content and it does nothing while that panel is the root.

The root is now a `DockPanel` with the box docked left, which leaves the label a real width to wrap inside. `UiKit.CheckBox` hands its label over as a wrapping `TextBlock` rather than a bare string. The card is still 380 wide in both columns below.

<img width="1960" height="2409" alt="board-install" src="https://github.com/user-attachments/assets/0afdb00d-a9f3-4625-9e76-67ec848d9b41" />


The export dialog fails differently for the same reason. Its window was pinned at `Width = 380`, and the caption is the wordmark plus `"KillerPDF - "` plus the translated suffix, 22 characters in en-US and up to 35 in tr-TR, so the title ran under the close button. `SizeToContent.WidthAndHeight` with `MinWidth = 380` gives the window the width its own caption asks for and keeps 380 everywhere shorter.

<img width="1960" height="2235" alt="board-export" src="https://github.com/user-attachments/assets/b4618678-4878-4743-9a1f-c463271aa148" />


I ran both builds in de-DE, fr-FR and pl-PL and opened each dialog from the app rather than measuring the controls in isolation. The install prompt goes from 267 to 281 tall. The export window goes from 380 to 404 wide in German, 396 in French and Polish. en-US I checked by measuring the control rather than running it, and it is unchanged in both dialogs, which was the case I was most worried about.

`UiKit.Radio` is untouched. It builds its own template around the same horizontal `StackPanel`, but its labels are format names like PNG and JPEG that no locale grows.

`ShowTwoCheckPrompt` keeps its 380 width. A label that wraps does not need a wider card.

This is the second half of #223. The drop-downs clipping their last row are a separate cause, and they are in #225.

Cut off `6582c76`, so it needs #218 to build.
