### PR TITLE
Let the combo popup take the height its own items ask for

### DIFF
--- a/Controls/PickerStyles.xaml
+++ b/Controls/PickerStyles.xaml
@@ -727,7 +727,7 @@
                                     Margin="0,2,6,6"
                                     MinWidth="{Binding ActualWidth,
                                                RelativeSource={RelativeSource TemplatedParent}}"
-                                    MaxHeight="220">
+                                    MaxHeight="{TemplateBinding MaxDropDownHeight}">
                                 <Border.Effect>
                                     <DropShadowEffect Color="Black" BlurRadius="12" ShadowDepth="2" Direction="270" Opacity="0.5"/>
                                 </Border.Effect>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -894,7 +894,7 @@
                                         Margin="0,2,6,6"
                                         MinWidth="{Binding ActualWidth,
                                                    RelativeSource={RelativeSource TemplatedParent}}"
-                                        MaxHeight="220">
+                                        MaxHeight="{TemplateBinding MaxDropDownHeight}">
                                     <Border.Effect>
                                         <DropShadowEffect Color="Black" BlurRadius="12" ShadowDepth="2" Direction="270" Opacity="{DynamicResource FlyoutShadowOpacity}"/>
                                     </Border.Effect>


### PR DESCRIPTION
The Watermark Position, Page Numbers Position and Zoom lists in #223 all scroll when they do not need to. All three are eight items, and eight items fit.

Both copies of the ComboBox template cap the popup on the Border instead of the ComboBox:

```xml
MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
MaxHeight="220">
```

Same two lines in `MainWindow.xaml` and `Controls/PickerStyles.xaml`. Sitting there, the cap wins over whatever height the list asks for, and it swallows `MaxDropDownHeight` on the way past.

The eight zoom rows want a 222px popup. The cap is 220. Two pixels is enough to leave the list scrollable for good, and the track never goes away. The shortfall scales with the row height, so the screenshots in the issue lose a lot more than two pixels.

<img width="1400" height="1005" alt="board-combo" src="https://github.com/user-attachments/assets/51cf8bc6-7fe1-41fe-ba70-323d43a8123d" />


The cap now reads `MaxDropDownHeight`. Unset, that is `SystemParameters.PrimaryScreenHeight / 3`, the stock ComboBox default, 720 on the display I am on. Long lists still cap. Short ones stop scrolling.

Two callers have been asking for a taller popup and getting 220 anyway. `Shell/TextSettingsBar.cs:498` sets `MaxDropDownHeight = 320` for its font list, and `Controls/StampWindow.cs:320` does the same for the watermark font. Both start working here without a change of their own.

I did not add a setter to either `DarkComboBox` style. That would be a second fixed number to keep in step across two copies of the template, and the two font pickers already set it per combo, which is the pattern here. If you would rather pin an explicit default, say so and I will put it in both styles.

Long lists still slice their last row. A font list cuts at the boundary the way any stock combo does, and there it is doing a job, because there is more below. The eight-item lists never were.

I watched the zoom list, not the two Position lists. Same template, same eight items, and `MakePosCombo` fills both from the same `Positions` table.

Same two templates as #219, different hunks, so they apply in either order. Cut off `6582c76`, so it needs #218 to build.
