### PR TITLE
Save multi-select-only form edits

### DIFF
--- a/KillerPDF.Tests/PdfEngineIntegrationTests.cs
+++ b/KillerPDF.Tests/PdfEngineIntegrationTests.cs
@@ -441,6 +441,43 @@ public sealed class PdfEngineIntegrationTests
         }
     }
 
+    [Fact]
+    public void ApplyFormValues_WritesABatchOfOnlyMultiSelectValues()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"killerpdf-multi-{Guid.NewGuid():N}.pdf");
+        try
+        {
+            byte[] source = new PdfDocumentBuilder()
+                .AddBlankPage()
+                .AddMultiSelectListBox(0, "customer.colours", 20, 20, 140, 96,
+                    ["Red", "Green", "Blue", "Amber"], ["Green", "Blue"])
+                .Build();
+            File.WriteAllBytes(path, source);
+
+            PdfEngineIntegration.ApplyFormValues(path, new PdfEngineIntegration.FormEdits(
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, IReadOnlyList<string>>
+                {
+                    ["customer.colours"] = new[] { "Red", "Amber" }
+                },
+                new Dictionary<string, bool>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, double>()));
+
+            byte[] result = File.ReadAllBytes(path);
+            Assert.True(result.AsSpan(0, source.Length).SequenceEqual(source));
+            PdfFormWidgetInfo widget = Assert.Single(
+                PdfEngineIntegration.ReadPageFormWidgets(PdfDocument.Open(result), 0),
+                candidate => candidate.FieldName == "customer.colours");
+            Assert.Equal(new[] { "Red", "Amber" }, widget.Values);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
     [Theory]
     [InlineData("don’t")]
     [InlineData("a—b")]

--- a/Services/PdfEngineIntegration.cs
+++ b/Services/PdfEngineIntegration.cs
@@ -162,6 +162,7 @@ internal static class PdfEngineIntegration
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         ArgumentNullException.ThrowIfNull(edits);
         if (edits.TextValues.Count == 0 && edits.ChoiceValues.Count == 0
+            && edits.MultiChoiceValues.Count == 0
             && edits.CheckBoxValues.Count == 0 && edits.RadioValues.Count == 0)
             return;
         PdfDocument document = PdfDocument.Open(File.ReadAllBytes(path));


### PR DESCRIPTION
`ApplyFormValues` gained a `MultiChoiceValues` loop, but the early return above it still tests only the other four dictionaries.
A batch holding nothing but multi-select changes returns before it reaches its own loop, so the edit is dropped and nothing reports a failure.

In the app that means changing only a multi-select list box and hitting Save writes a revision with page rotations in it and no field values at all.

One line adds `MultiChoiceValues` to that guard.

`ApplyFormValues_WritesABatchOfOnlyMultiSelectValues` builds a four-option multi-select, applies a batch containing only that change, and reads the field back.
It fails without the fix and passes with it.

Checked on `d0c5588` with .NET SDK 10.0.400: 1427 engine and 196 app tests pass on this branch.

One thing I deliberately did not touch: the guard is still a flat test against each dictionary in turn, rather than something that cannot miss one again.
Restructuring it is a wider change than this bug needs.

Turned up with a 22-widget form fixture while testing beta.1.
