### PR TITLE
Keep list box rows inside the field rectangle

### DIFF
--- a/engine/KillerPdf.Engine.Tests/Authoring/PdfListBoxOverflowTests.cs
+++ b/engine/KillerPdf.Engine.Tests/Authoring/PdfListBoxOverflowTests.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using KillerPdf.Engine.Authoring;
+using KillerPdf.Engine.Documents;
+using KillerPdf.Engine.Objects;
+using Xunit;
+
+namespace KillerPdf.Engine.Tests.Authoring;
+
+public sealed class PdfListBoxOverflowTests
+{
+    // Four 12pt options need roughly 58 points of rows. In a 48 point box the last
+    // rows fall below the field, and the appearance stream's clip path is what keeps
+    // them out of the drawn result. Rows must stay evenly spaced: clamping an
+    // overflowing row up to the bottom edge leaves it a few points from the row above
+    // and their glyphs overlap.
+    [Fact]
+    public void RowsStayEvenlySpacedWhenOptionsOverflowTheField()
+    {
+        double[] origins = TextOrigins(ListBoxAppearance(height: 48));
+
+        Assert.True(origins.Length >= 3, "Expected at least three rows to be written.");
+        double spacing = origins[0] - origins[1];
+        for (int index = 1; index < origins.Length; index++)
+        {
+            double gap = origins[index - 1] - origins[index];
+            Assert.True(Math.Abs(gap - spacing) < 0.01,
+                $"Row {index} sits {gap} below row {index - 1}, but the rows above it are " +
+                $"{spacing} apart. An overflowing row must keep its true position so the clip " +
+                "path can discard it, rather than being pinned to the bottom of the field.");
+        }
+    }
+
+    // The selection highlight is subject to the same clamp and must move with its row.
+    [Fact]
+    public void SelectionHighlightTracksItsOwnRow()
+    {
+        string content = ListBoxAppearance(height: 48, selected: "Four");
+        Match highlight = Regex.Match(content, @"0\.75 g\s+1 (-?[\d.]+) ");
+
+        Assert.True(highlight.Success, "No selection highlight was written.");
+        Assert.True(Number(highlight.Groups[1].Value) < 1,
+            "The highlight for the last of four options in a 48 point box should sit below " +
+            "the field, where the clip removes it, rather than being pinned to the bottom edge.");
+    }
+
+    // A field whose options all fit must be unaffected.
+    [Fact]
+    public void FieldsThatFitAreUnchanged()
+    {
+        double[] origins = TextOrigins(ListBoxAppearance(height: 120));
+
+        Assert.Equal(4, origins.Length);
+        Assert.All(origins, origin => Assert.True(origin > 0));
+    }
+
+    private static string ListBoxAppearance(double height, string? selected = "Two")
+    {
+        PdfDocument document = PdfDocument.Open(new PdfDocumentBuilder()
+            .AddBlankPage()
+            .AddListBox(0, "rows", 0, 0, 200, height,
+                ["One", "Two", "Three", "Four"], selectedValue: selected)
+            .Build());
+        PdfDictionary catalog = ResolveDictionary(document, document.Trailer[Name("Root")]);
+        PdfDictionary field = ResolveDictionary(document, Assert.IsType<PdfArray>(
+            Assert.IsType<PdfDictionary>(catalog[Name("AcroForm")])[Name("Fields")])[0]);
+        PdfStream appearance = Assert.IsType<PdfStream>(document.Resolve(
+            Assert.IsType<PdfIndirectReference>(
+                Assert.IsType<PdfDictionary>(field[Name("AP")])[Name("N")])));
+        return Encoding.ASCII.GetString(appearance.EncodedData.Span);
+    }
+
+    private static double[] TextOrigins(string content) =>
+        Regex.Matches(content, @"(-?[\d.]+) (-?[\d.]+) Td")
+            .Select(match => Number(match.Groups[2].Value))
+            .ToArray();
+
+    private static double Number(string value) =>
+        double.Parse(value, CultureInfo.InvariantCulture);
+
+    private static PdfDictionary ResolveDictionary(PdfDocument document, PdfObject value) =>
+        Assert.IsType<PdfDictionary>(document.Resolve(Assert.IsType<PdfIndirectReference>(value)));
+    private static PdfName Name(string value) => new(Encoding.ASCII.GetBytes(value));
+}

--- a/engine/KillerPdf.Engine/Authoring/PdfDocumentBuilder.cs
+++ b/engine/KillerPdf.Engine/Authoring/PdfDocumentBuilder.cs
@@ -4320,14 +4320,14 @@ public sealed partial class PdfDocumentBuilder
             if (field.SelectedValues.Contains(option.ExportValue, StringComparer.Ordinal))
             {
                 WriteAscii(output,
-                    $"0.75 g\n1 {FormatNumber(Math.Max(1, rowBottom))} " +
+                    $"0.75 g\n1 {FormatNumber(rowBottom)} " +
                     $"{FormatNumber(Math.Max(0, field.Width - 2))} {FormatNumber(rowHeight)} re\nf\n");
             }
             double textX = ChoiceTextX(field, option.DisplayValue);
             WriteAscii(output,
                 $"BT\n{NameToken(fontResource)} {FormatNumber(field.FontSize)} Tf\n" +
                 $"{ColorOperands(style.TextColor)} rg\n" +
-                $"{FormatNumber(textX)} {FormatNumber(Math.Max(1, rowBottom + (rowHeight - field.FontSize) / 2))} Td\n");
+                $"{FormatNumber(textX)} {FormatNumber(rowBottom + (rowHeight - field.FontSize) / 2)} Td\n");
             WriteShownText(output, option.DisplayValue, field.EmbeddedFont, fontUsage);
             output.Write("ET\n"u8);
             rowTop = rowBottom;


### PR DESCRIPTION
This is the list box row half of #245, still present in beta.1.

`BuildListBoxAppearance` clamps both the selection highlight and the text origin with `Math.Max(1, rowBottom)`, which pulls any row falling below the field back to the bottom edge.
With four 12pt options in a 48pt box, rows three and four land on the same baseline and print on top of each other.

The appearance stream already sets a clip path over the field rectangle, so the row positions can be written as they are and the clip discards whatever does not fit.

Fields whose options all fit are byte-identical, so nothing that renders correctly today moves.

Three tests, each failing without the fix and passing with it:

- `RowsStayEvenlySpacedWhenOptionsOverflowTheField`
- `SelectionHighlightTracksItsOwnRow`
- `FieldsThatFitAreUnchanged`

Checked on `d0c5588` with .NET SDK 10.0.400: 1430 engine and 195 app tests pass on this branch.

One thing I deliberately did not touch: rows past the bottom of the field are now drawn in the right place and then clipped, rather than being reachable.
Making them reachable is a viewer change rather than an appearance one, so it does not belong here.
