### PR TITLE
Let the mouse pick from a form field dropdown

### DIFF
--- a/Controls/Viewer/PdfViewer.Annotations.cs
+++ b/Controls/Viewer/PdfViewer.Annotations.cs
@@ -2418,7 +2418,11 @@ namespace KillerPDF.Controls
             {
                 if (current is FrameworkElement fe && fe.Tag as string == FormOverlayTag)
                     return true;
-                current = VisualTreeHelper.GetParent(current);
+                // A choice field's open dropdown lives in a Popup, whose visual tree dead-ends at
+                // its PopupRoot instead of reaching the tagged ComboBox. The logical tree does
+                // cross that boundary (a generated ComboBoxItem's logical parent is the ComboBox),
+                // so prefer it and fall back to the visual walk inside templates.
+                current = LogicalTreeHelper.GetParent(current) ?? GetAnyParent(current);
             }
             return false;
         }

--- a/Controls/Viewer/PdfViewer.Zoom.cs
+++ b/Controls/Viewer/PdfViewer.Zoom.cs
@@ -259,6 +259,13 @@ namespace KillerPDF.Controls
         // actually on a page (left to that page's own surface). Shared by off-page crop and marquee starts.
         private Canvas? ResolveMarginOverlay(MouseButtonEventArgs e)
         {
+            // A press inside a form field is the field's own interaction, never a margin gesture.
+            // This includes a choice field's dropdown items: the popup floats outside every page
+            // overlay's visual tree, so without this check the press reads as a margin click, the
+            // marquee (or crop) starts, and taking the mouse capture closes the dropdown and
+            // discards the click.
+            if (e.OriginalSource is DependencyObject fieldSrc && IsFormFieldElement(fieldSrc))
+                return null;
             if (_viewMode == ViewMode.Continuous)
             {
                 if (e.OriginalSource is DependencyObject osc && IsWithinPageOverlay(osc)) return null;


### PR DESCRIPTION
Clicking an item in a form choice field's dropdown does nothing.
The list closes and the field keeps its old value.
Choosing with the keyboard works, which is what pointed at mouse routing rather than at the field's bindings.

The dropdown lives in a `Popup`, and a Popup's visual tree ends at its own root instead of reaching back to the `ComboBox` on the page overlay.
Every mouse guard here walks the visual tree, so a click on a dropdown item looks like a bare margin press.
The marquee then starts, and taking the mouse capture closes the dropdown and throws the click away.

Guarding the marquee alone is not enough: the page overlay's own mouse-down handler misreads the click the same way and takes the capture one layer down.

`IsFormFieldElement` now prefers the logical parent, which does cross the popup boundary since a generated `ComboBoxItem`'s logical parent is its `ComboBox`, and `ResolveMarginOverlay` treats any press inside a form field as the field's own interaction rather than a margin gesture.

Proven with a `LostMouseCapture` stack trace on a live click rather than by reading the code, after three wrong theories.
The trace named `StartMarqueeDraw` taking the capture.

Verified with a P/Invoke click harness: red before, green after on `choice.combo`, `choice.comboMapped` and `choice.comboEditable`, with the margin marquee still working zoomed out.
1427 engine and 195 app tests pass on this branch off `d0c5588`.

`IsFormFieldElement` is shared with two other handlers, the annotation hit test at `Annotations.cs:902` and the move handler at `:1386`.
Both were making the same misclassification on popup content, so both get the correction.
I have not gone looking for other visual-tree walks with the same assumption.

This one is not a 1.8 regression.
It reproduces on 1.7.5 too, and both files exist on `main`.
I have not touched `main`, so whether it is worth a backport is your call.
