### PR TITLE
Keep form field list rows readable

### DIFF
--- a/Controls/Viewer/PdfViewer.Forms.cs
+++ b/Controls/Viewer/PdfViewer.Forms.cs
@@ -375,6 +375,7 @@ namespace KillerPDF.Controls
                         ItemsSource = f.Options,
                         DisplayMemberPath = nameof(FormChoiceItem.DisplayValue),
                         SelectionMode = SelectionMode.Multiple,
+                        ItemContainerStyle = (Style)FindResource("FormFieldListBoxItem"),
                         Foreground = Brushes.Black,
                         Background = fieldBg,
                         FontSize = f.DaFontPt > 0.5 && f.Scale > 0

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1113,6 +1113,41 @@
             </Setter>
         </Style>
 
+        <!-- Form field rows carry the PDF's own colours, not the app chrome. The implicit
+             ListBoxItem style above paints TextBrush on every item in this window, which is
+             near-white in the dark themes and vanishes against a form field's pale fill.
+             A ListBox can only pass its own Foreground down by inheritance, and a style
+             setter outranks that, so the overlay opts out with an explicit container style
+             the same way the file dialog's lists do. Neither trigger touches Foreground, so
+             the text stays readable in every state. -->
+        <Style x:Key="FormFieldListBoxItem" TargetType="ListBoxItem">
+            <Setter Property="Padding" Value="2,0"/>
+            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderThickness="0"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#333399FF"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#663399FF"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         </ResourceDictionary>
     </Window.Resources>
 


### PR DESCRIPTION
Multi-select list box rows in the form overlay are near-white on the PDF's own pale fill, so they can only be read while a row is hovered or selected and a dark band appears behind them.
Dark themes only.

MainWindow's implicit `ListBoxItem` style paints every item in the window with `TextBrush`.
A form field overlay draws on the document rather than on app chrome, so it inherits a colour meant for a dark background.

Setting `Foreground` on the `ListBox` cannot fix it.
A ListBox passes its own Foreground down by inheritance, and a style setter outranks inheritance, so it never reaches the containers.
The overlay now supplies its own container style, the same way the file dialog's lists already do.

One thing I deliberately did not touch: the implicit style itself.
It is correct for every other list in the window, and narrowing it would mean auditing all of them.

Confirmed by eye on a form fixture across the dark themes.
No automated test on this one: it comes down to brush resolution in a generated container, so asserting it would mean standing up a full visual tree.
1427 engine and 195 app tests pass on this branch off `d0c5588`.
