### PR TITLE
Let form field lists take the wheel

### DIFF
--- a/Controls/Viewer/PdfViewer.Zoom.cs
+++ b/Controls/Viewer/PdfViewer.Zoom.cs
@@ -36,6 +36,12 @@ namespace KillerPDF.Controls
         // internal: PdfViewer's XAML binds this and forwards to it.
         internal void PagePreview_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
+            // A form field list keeps the wheel while it still has rows to reach. Its overlay
+            // sits inside PagePreviewPanel, so this tunnelling handler would otherwise scroll
+            // the page out from under a list the user is reading, and a field taller than its
+            // box could never be scrolled at all.
+            if (FieldListWantsWheel(e.OriginalSource as DependencyObject, e.Delta)) return;
+
             // #209: match the standard Windows/browser gesture and reuse the same path as a
             // physical tilt wheel. Wheel-down moves right; wheel-up moves left.
             if (Keyboard.Modifiers == ModifierKeys.Shift)
@@ -116,6 +122,24 @@ namespace KillerPDF.Controls
             }
             _wheelPageFlipGate.NoteContentScroll(DateTime.UtcNow);
             ScrollWheel(e);
+        }
+
+        // True when the wheel sits over a scrollable control inside the page overlay that still
+        // has somewhere to go in this direction. The walk stops at PagePreviewPanel, which is
+        // itself a ScrollViewer and owns the wheel from that point up.
+        private bool FieldListWantsWheel(DependencyObject? source, int delta)
+        {
+            for (DependencyObject? node = source;
+                 node is not null && !ReferenceEquals(node, PagePreviewPanel);
+                 node = node is Visual or System.Windows.Media.Media3D.Visual3D
+                     ? VisualTreeHelper.GetParent(node) : null)
+            {
+                if (node is not ScrollViewer inner || inner.ScrollableHeight <= 0) continue;
+                return delta > 0
+                    ? inner.VerticalOffset > 0
+                    : inner.VerticalOffset < inner.ScrollableHeight;
+            }
+            return false;
         }
 
         // Zoom ratio per full wheel notch (e.Delta = 120) for Ctrl+scroll. 1.1 lands close to the


### PR DESCRIPTION
A form field list box taller than its own field cannot be scrolled, so any option past the bottom edge is unreachable.

The page panel's tunnelling wheel handler runs before the overlay sees the event, so the page scrolls instead of the list.

The handler now defers to a scrollable control under the cursor while that control still has room to move, and takes the wheel back at its boundary.
The walk stops at `PagePreviewPanel`, which is itself a ScrollViewer and owns the wheel from that point up.

One thing I deliberately did not change: the boundary behaviour.
Handing the wheel back at the end of the inner list is what keeps the existing edge page-flip gesture intact, and I would rather that stayed as it is than make the list greedy.

Confirmed by hand on a form fixture, scrolling a list past its field and then continuing past the boundary to check the page still takes over.
No automated test on this one: it is wheel routing through a live visual tree.
1427 engine and 195 app tests pass on this branch off `d0c5588`.
