### PR TITLE
Clear a per-user protocol key left behind by a copy that is gone

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -148,6 +148,10 @@ namespace KillerPDF
             // Refresh the current executable path for the browser extension handoff. This stays
             // after silent install, uninstall, and CLI dispatch so those headless paths never
             // register a protocol under an elevated or service account.
+            // #246: clear a per-user registration left behind by a copy that is now gone, before
+            // the refresh below. A machine-wide install can never do this by rewriting the key -
+            // that is exactly what #183 forbids - so removing the dead one is the only way back.
+            Services.ProtocolRegistrar.RemoveStaleRegistration(Registry.CurrentUser);
             // #183: skip the per-user refresh when running from the machine-wide install - the
             // elevated installer already registered the handler in HKLM for all users, and an
             // HKCU copy would shadow it for just this user.

--- a/KillerPDF.Tests/ProtocolRegistrarStaleTests.cs
+++ b/KillerPDF.Tests/ProtocolRegistrarStaleTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using KillerPDF.Services;
+using Microsoft.Win32;
+using Xunit;
+
+namespace KillerPDF.Tests;
+
+/// <summary>
+/// #246: a per-user protocol registration outlives the copy that wrote it, and HKCU shadows
+/// HKLM, so a dead handler hijacks the browser handoff from a working machine-wide install.
+///
+/// ProtocolRegistrar takes its registry root as a parameter, so every case here runs against a
+/// scratch key under HKCU and never touches the real Software\Classes\killerpdf.
+/// </summary>
+public sealed class ProtocolRegistrarStaleTests : IDisposable
+{
+    private const string CommandPath = @"Software\Classes\killerpdf\shell\open\command";
+
+    // Flat, not nested under a shared parent: DeleteSubKeyTree in Dispose then removes the whole
+    // thing rather than leaving an empty Software\KillerPDF.Tests behind on the tester's machine.
+    private readonly string _rootPath = @"Software\KillerPDF.Tests-" + Guid.NewGuid().ToString("N");
+    private readonly RegistryKey _root;
+    private readonly string _directory;
+
+    public ProtocolRegistrarStaleTests()
+    {
+        _root = Registry.CurrentUser.CreateSubKey(_rootPath)
+            ?? throw new InvalidOperationException("The scratch registry root could not be created.");
+        _directory = Path.Combine(Path.GetTempPath(), "kpdf-protocol-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        try { Registry.CurrentUser.DeleteSubKeyTree(_rootPath, throwOnMissingSubKey: false); } catch { }
+        try { Directory.Delete(_directory, recursive: true); } catch { }
+    }
+
+    private string LivingExecutable()
+    {
+        string path = Path.Combine(_directory, "KillerPDF.App.exe");
+        File.WriteAllBytes(path, []);
+        return path;
+    }
+
+    private string DeletedExecutable() => Path.Combine(_directory, "gone", "KillerPDF.App.exe");
+
+    private bool RegistrationExists()
+    {
+        using RegistryKey? command = _root.OpenSubKey(CommandPath);
+        return command != null;
+    }
+
+    [Fact]
+    public void RemoveStaleRegistration_DeletesARegistrationWhoseExecutableIsGone()
+    {
+        ProtocolRegistrar.Register(_root, DeletedExecutable());
+        Assert.True(RegistrationExists());
+
+        ProtocolRegistrar.RemoveStaleRegistration(_root);
+
+        Assert.False(RegistrationExists());
+    }
+
+    [Fact]
+    public void RemoveStaleRegistration_KeepsARegistrationWhoseExecutableStillExists()
+    {
+        string executable = LivingExecutable();
+        ProtocolRegistrar.Register(_root, executable);
+
+        ProtocolRegistrar.RemoveStaleRegistration(_root);
+
+        Assert.True(RegistrationExists());
+        Assert.Equal(executable, ProtocolRegistrar.RegisteredAppPath(_root));
+    }
+
+    [Fact]
+    public void RemoveStaleRegistration_DoesNothingWhenThereIsNoRegistration()
+    {
+        ProtocolRegistrar.RemoveStaleRegistration(_root);
+
+        Assert.False(RegistrationExists());
+    }
+
+    [Fact]
+    public void RegisteredAppPath_ReadsThePathBackOutOfTheQuotedCommand()
+    {
+        // The command is written as "<appPath>" "%1"; a path with a space is the case that
+        // makes the quotes load-bearing.
+        string executable = Path.Combine(_directory, "Program Files", "KillerPDF.App.exe");
+
+        ProtocolRegistrar.Register(_root, executable);
+
+        Assert.Equal(executable, ProtocolRegistrar.RegisteredAppPath(_root));
+    }
+
+    [Fact]
+    public void RegisteredAppPath_ReturnsNullWhenNothingIsRegistered()
+    {
+        Assert.Null(ProtocolRegistrar.RegisteredAppPath(_root));
+    }
+}

--- a/Services/ProtocolRegistrar.cs
+++ b/Services/ProtocolRegistrar.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using Microsoft.Win32;
 
 namespace KillerPDF.Services
@@ -31,6 +32,39 @@ namespace KillerPDF.Services
                 command?.SetValue("", $"\"{appPath}\" \"%1\"");
             }
             catch (Exception ex) { Debug.WriteLine($"Failed to register KillerPDF protocol: {ex.Message}"); }
+        }
+
+        /// <summary>The executable a registration points at, or null when there is none to read.</summary>
+        internal static string? RegisteredAppPath(RegistryKey root)
+        {
+            try
+            {
+                using var command = root.OpenSubKey(RegistryPath + @"\shell\open\command");
+                if (command?.GetValue("") is not string value) return null;
+                // Register writes the command as "<appPath>" "%1", so the path is the first quoted span.
+                int open = value.IndexOf('"');
+                if (open < 0) return null;
+                int close = value.IndexOf('"', open + 1);
+                return close > open ? value[(open + 1)..close] : null;
+            }
+            catch { return null; }
+        }
+
+        // #246: a per-user registration outlives the copy that wrote it. The portable launcher
+        // extracts to a per-run directory and deletes it on exit, so a portable session leaves the
+        // handler aimed at a path that is already gone - and HKCU shadows HKLM, so it hijacks the
+        // browser handoff from a working machine-wide install until something removes it. Nothing
+        // did: Unregister only ran from the two install-removal paths and from uninstall.
+        /// <summary>
+        /// Removes a per-user registration whose executable no longer exists, leaving a valid one
+        /// alone. Deleting is the safe direction here - the handler being removed is already dead,
+        /// and unlike a write it can never shadow the machine-wide registration (#183).
+        /// </summary>
+        internal static void RemoveStaleRegistration(RegistryKey root)
+        {
+            string? appPath = RegisteredAppPath(root);
+            if (appPath == null || File.Exists(appPath)) return;
+            Unregister(root);
         }
 
         internal static void Unregister() => Unregister(Registry.CurrentUser);


### PR DESCRIPTION
Fixes the part of #246 that is still open after your beta.1 fix.

`RemovePerUserInstall` dropping the protocol key sorted the dual-install repair path. What is left is a key written by a copy that was never an install, because `Unregister` only ever ran from the two install-removal paths and from uninstall. Nothing removes a registration once the exe behind it is gone.

The portable launcher makes that routine rather than rare. `RunPortable` extracts to a per-run directory and deletes it in a `finally`, so a portable session registers `HKCU\Software\Classes\killerpdf` at a path that stops existing the moment the window closes. HKCU shadows HKLM, so from then on the browser handoff goes to a directory that is gone, and a machine-wide install has no way to take it back - #183 is exactly the rule that stops it rewriting HKCU.

So the fix removes rather than writes. Startup drops a per-user registration whose executable is missing, before the existing refresh. A delete cannot shadow anything, which is why it is safe to run in the machine copy too, and the machine copy is the only thing that reaches a machine already in this state.

Two things I deliberately did not do:

- **Stop portable runs registering in the first place.** That is the other half, and it is a behaviour change rather than a repair: a portable user would lose the `killerpdf://` handoff entirely, or the registration would have to point at the durable launcher exe instead of the extracted one. Features are frozen and it is your call, so I have left it as a question on the issue rather than deciding it in a PR.
- **Touch the launcher.** I started there, on the theory that it owns the lifecycle and could restore what it captured. It does not work: the `finally` does not run on a kill, a logoff or a reboot, which is how a fair share of sessions end, and a blind restore would clobber legitimate changes made in between - your own `InstallAndRelaunch` deletes that key on purpose when moving a user to an all-users install, and a restore would resurrect it pointing at the copy the installer just removed.

Five tests, and I checked them both ways. Removing the sweep turns the missing-executable test red; making it delete unconditionally turns the still-exists test red. `ProtocolRegistrar` was already linked into `KillerPDF.Tests`, and it takes its registry root as a parameter, so they run against a scratch key and never touch the real one.

Also verified against the real `HKCU` by calling the sweep directly, with nothing else running so it is the only thing that could have moved the key:

```
case 1: target gone
  before : "...\KillerPDF\Portable\1.8.0-9999-deadbeef\KillerPDF.App.exe" "%1"
  after  : (absent)
case 2: target exists
  before : "...\sweep.exe" "%1"
  after  : "...\sweep.exe" "%1"
case 3: nothing registered
  before : (absent)
  after  : (absent)
```

Build clean, 1,430 engine and 204 application tests pass.

What I did not test end to end: the ordering at the call site. A dev build re-registers itself a line later, so a live startup cannot show which of the two cleared the key. That part is a two-line read rather than something I watched.
