### PR TITLE
Keep the sidebar page total with the pages it counts

### DIFF
--- a/Controls/SidebarPageBinding.cs
+++ b/Controls/SidebarPageBinding.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Windows.Controls;
+
+namespace KillerPDF.Controls
+{
+    /// <summary>The sidebar thumbnail list and the total above it, moved together.
+    ///
+    /// They describe one document between them, so they are set in one place. They used to be set
+    /// apart: the only writer of a real total was BootstrapDocumentView, on the render path, which
+    /// a pane switch and a temp reload both skip on purpose. That left the sidebar listing one
+    /// document's pages under another document's count.
+    ///
+    /// The count comes off the bound list rather than off the document, so the number cannot
+    /// disagree with the thumbnails it sits above, whichever pane is in context.</summary>
+    internal sealed class SidebarPageBinding(ItemsControl list, TextBlock total)
+    {
+        /// <summary>What the total reads with no document behind it. The two teardown paths in
+        /// Shell/FileOperations.cs and PdfViewer.Tabs.cs still write this inline.</summary>
+        internal const string Empty = "/ -";
+
+        internal void Show(IList? items)
+        {
+            // Re-binding the same list rebuilds every container, so only assign on a real change.
+            if (!ReferenceEquals(list.ItemsSource, items)) list.ItemsSource = items;
+            total.Text = items is null ? Empty : $"/ {items.Count}";
+        }
+    }
+}

--- a/KillerPDF.Tests/KillerPDF.Tests.csproj
+++ b/KillerPDF.Tests/KillerPDF.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="..\Services\Signing\PdfSigner.cs" Link="Services\Signing\PdfSigner.cs" />
     <Compile Include="..\Models\StampModels.cs" Link="Models\StampModels.cs" />
     <Compile Include="..\Controls\FlyoutPlacement.cs" Link="Controls\FlyoutPlacement.cs" />
+    <Compile Include="..\Controls\SidebarPageBinding.cs" Link="Controls\SidebarPageBinding.cs" />
     <!-- Data only, by design: OcrLanguages.cs itself reaches App and OcrNativeBootstrap, which a
          catalog check has no business dragging in. See OcrCatalogTests. -->
     <Compile Include="..\Services\OcrCatalog.cs" Link="Services\OcrCatalog.cs" />

--- a/KillerPDF.Tests/SidebarPageBindingTests.cs
+++ b/KillerPDF.Tests/SidebarPageBindingTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Threading;
+using System.Windows.Controls;
+using KillerPDF.Controls;
+using Xunit;
+
+namespace KillerPDF.Tests;
+
+public sealed class SidebarPageBindingTests
+{
+    // xUnit runs tests on an MTA thread and WPF elements refuse to construct there, so each body
+    // runs on a short-lived STA thread with any failure rethrown on the test thread.
+    private static void OnSta(Action body)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() => { try { body(); } catch (Exception ex) { failure = ex; } });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (failure is not null) throw failure;
+    }
+
+    private static (SidebarPageBinding Binding, ListBox List, TextBlock Total) NewSidebar()
+    {
+        var list = new ListBox();
+        var total = new TextBlock();
+        return (new SidebarPageBinding(list, total), list, total);
+    }
+
+    /// <summary>The pane-switch case: showing another document's pages must move the total with
+    /// them. This is what regressed - the list changed and the total kept the old count.</summary>
+    [Fact]
+    public void TotalFollowsTheListOnEveryShow() => OnSta(() =>
+    {
+        var (binding, _, total) = NewSidebar();
+
+        binding.Show(new object[4]);
+        Assert.Equal("/ 4", total.Text);
+
+        binding.Show(new object[3]);          // focus the three page pane
+        Assert.Equal("/ 3", total.Text);
+
+        binding.Show(new object[4]);          // and back again
+        Assert.Equal("/ 4", total.Text);
+    });
+
+    /// <summary>The insert case: a page dragged in from the other pane grows the list, and the
+    /// total has to grow with it rather than keep the pre-insert count.</summary>
+    [Fact]
+    public void TotalGrowsWhenThePageListGrows() => OnSta(() =>
+    {
+        var (binding, _, total) = NewSidebar();
+
+        binding.Show(new object[3]);
+        Assert.Equal("/ 3", total.Text);
+
+        binding.Show(new object[4]);
+        Assert.Equal("/ 4", total.Text);
+    });
+
+    [Fact]
+    public void NoDocumentClearsBothTheListAndTheTotal() => OnSta(() =>
+    {
+        var (binding, list, total) = NewSidebar();
+        binding.Show(new object[2]);
+
+        binding.Show(null);
+
+        Assert.Null(list.ItemsSource);
+        Assert.Equal(SidebarPageBinding.Empty, total.Text);
+    });
+
+    [Fact]
+    public void TotalCountsTheListThatIsActuallyBound() => OnSta(() =>
+    {
+        var (binding, list, total) = NewSidebar();
+        var pages = new object[7];
+
+        binding.Show(pages);
+
+        Assert.Same(pages, list.ItemsSource);
+        Assert.Equal("/ 7", total.Text);
+    });
+
+    /// <summary>Re-binding an identical list rebuilds every container, so the same instance must
+    /// not be reassigned. The total is still written, which costs nothing and cannot drift.</summary>
+    [Fact]
+    public void ShowingTheSameListAgainDoesNotRebindIt() => OnSta(() =>
+    {
+        var (binding, list, total) = NewSidebar();
+        var pages = new object[5];
+        binding.Show(pages);
+
+        list.ItemsSource = null;              // stand in for a rebind we must not see repeated
+        binding.Show(pages);
+
+        Assert.Same(pages, list.ItemsSource); // reassigned only because it genuinely changed
+        Assert.Equal("/ 5", total.Text);
+    });
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -292,6 +292,8 @@ namespace KillerPDF
         private readonly Grid _portableBadge = null!;
         private readonly TextBox _pageJumpBox = null!;
         private readonly TextBlock _pageTotalLabel = null!;
+        /// <summary>The sidebar list and the total above it, so the two cannot be set apart.</summary>
+        private readonly Controls.SidebarPageBinding _sidebarPages = null!;
 
         // Dirty / unsaved-change tracking
         private bool _isDirty { get => ActiveViewer.IsDirtyRef; set => ActiveViewer.IsDirtyRef = value; }
@@ -358,6 +360,7 @@ namespace KillerPDF
             _portableBadge = (Grid)FindName("PortableBadge")!;
             _pageJumpBox = (TextBox)FindName("PageJumpBox")!;
             _pageTotalLabel = (TextBlock)FindName("PageTotalLabel")!;
+            _sidebarPages = new Controls.SidebarPageBinding(PageList, _pageTotalLabel);
             // Both panes: each tracks the page under its own viewport. Pane B was never wired, so
             // its page counter, jump box and sidebar selection never moved as it scrolled.
             Viewer.WireScrollChanged();      // handler moved into the control with the render pipeline

--- a/Shell/PageOperations.cs
+++ b/Shell/PageOperations.cs
@@ -209,7 +209,7 @@ namespace KillerPDF
             // separately, so the other pane's decode is writing into ITS array and should be left
             // to finish - canceling it was what left a pane showing page labels with no pictures
             // after any focus change.
-            if (!ReferenceEquals(PageList.ItemsSource, cached)) PageList.ItemsSource = cached;
+            _sidebarPages.Show(cached);
             ActiveViewer.SyncPageListSelection(preservedPage);
         }
 
@@ -223,7 +223,7 @@ namespace KillerPDF
 
             if (_doc is null || _currentFile is null)
             {
-                PageList.ItemsSource = null;
+                _sidebarPages.Show(null);
                 return;
             }
 
@@ -251,7 +251,7 @@ namespace KillerPDF
                     if (prev != null) items[i].SetThumbnailDirect(prev);
                 }
             }
-            PageList.ItemsSource = items;
+            _sidebarPages.Show(items);
             ActiveViewer.SyncPageListSelection(preservedPage);
 
             // Hand the array to the pane it belongs to, so focusing away and back can re-seat it


### PR DESCRIPTION
The total above the sidebar thumbnails keeps whichever document rendered last.

Split with F10, put a four page document in one pane and a three page document in the other, then click between them. Both panes read `/ 3` while the four page document is focused, with its own four thumbnails listed directly underneath. It never catches up.

<img width="1320" height="560" alt="PR-before-after" src="https://github.com/user-attachments/assets/534037ee-c7fc-47f7-8c28-27f4d096a0bf" />

The only thing that writes a real total is `BootstrapDocumentView` (`Controls/Viewer/PdfViewer.Viewport.cs:1338`), and that is on the render path. Both places that change which document the sidebar is showing skip rendering deliberately:

- `FocusPane` restores the page list, outlines, zoom and tool, then stops short of a render because `RefreshPageList` re-decodes every page and that costs seconds on a large document. Its own comment already says where the total should end up: "Without it the sidebar, page count and status line keep describing the pane you just left" (`Shell/SplitPane.cs:493`).
- `SaveTempAndReload` calls `RefreshPageList()` and nothing that touches the total (`Shell/TempReload.cs:116`), so the stale reading comes back after any edit that changes the page count. Dragging a page in from the other pane leaves four thumbnails sitting under a `/ 3`, with the status bar reading `Page 2 of 4` at the same moment.

So the list and the total move together now, in `SidebarPageBinding`. The count comes off the bound list rather than the document, so it cannot disagree with the thumbnails above it even when `RunWithViewerContext` has swapped a background pane in.

It is a class holding the two controls rather than a method on `MainWindow` for one reason: a private method there is not reachable from a test. As a class the invariant can be tested directly, and all five tests fail against the old behaviour where the list was bound and the total left alone. One thing to flag, because it is your call and not mine: xUnit runs MTA and WPF elements will not construct there, so each test body runs on a short-lived STA thread. That is ten lines in `SidebarPageBindingTests` and no new package, but it is the first STA test in the project. Say the word and I will drop the tests and leave the fix.

Two things I deliberately did not touch:

- The teardown paths in `Shell/FileOperations.cs` and `PdfViewer.Tabs.cs`. Both already set the list and the total together, and both are long clear-everything sequences where routing one line through a helper would be churn. `SidebarPageBinding.Empty` says as much in its summary, so nobody has to go hunting for the other two writers.
- The write at `PdfViewer.Viewport.cs:1338`. It is redundant now, because `BootstrapDocumentView` calls `RefreshPageList` before it and gets the same value. I left it because it is also the only write that reaches the label from a non-active pane through `RunWithViewerContext`, and I have not worked that path out. Leaving it changes nothing and keeps this to one behaviour change.

Also checked by hand in the running app: toggled panes five times reading the label each pass, four page pane reads `/ 4` and three page pane reads `/ 3` every time, and after dragging a page across, the counter and the status bar agree at `3 / 4`.

Built on `develop/1.8.0` at `68912e4`, Windows 10. 0 warnings, 1433 engine and 236 app tests passing.
