### PR TITLE
Stop a killerpdf: launch crashing when it starts the app

### DIFF
--- a/Shell/PageOperations.cs
+++ b/Shell/PageOperations.cs
@@ -220,8 +220,14 @@ namespace KillerPDF
             var thumbnailOwner = ActiveViewer;
             // Cancel any in-flight thumbnail load for the previous file.
             _thumbCts?.Cancel();
-            _thumbCts = new System.Threading.CancellationTokenSource();
-            var ct = _thumbCts.Token;
+            // Hold the token locally rather than reading it back off _thumbCts. That property
+            // forwards to the ACTIVE TAB (PdfViewer.ThumbCts), and both sides are guarded on
+            // _active, so with no tab open the write is dropped and the read comes back null.
+            // A killerpdf: launch reaches here in exactly that state: it goes to
+            // OpenFromExternal, the one startup path that never calls EnsureInitialSession.
+            var freshCts = new System.Threading.CancellationTokenSource();
+            _thumbCts = freshCts;
+            var ct = freshCts.Token;
 
             if (_doc is null || _currentFile is null)
             {


### PR DESCRIPTION
Fixes #276.

A `killerpdf:` launch that starts the app crashes instead of opening. Bisected to `1afab91`, which moved four pane properties onto the active tab:

```csharp
internal System.Threading.CancellationTokenSource? ThumbCts
{
    get => _active?.ThumbCts;
    set { if (_active != null) _active.ThumbCts = value; }
}
```

`RefreshPageList` writes the loader token to `_thumbCts` and reads it back on the next line. A launch argument goes to `OpenFromExternal`, the one startup path that never calls `EnsureInitialSession`, so there is no active tab by the time `ContentRendered` gets there. The write is dropped, the read is null, and that is line 224 in the report.

Keeping the token in a local reads the same whenever a tab exists.

Checked on `5f1c897` with `killerpdf://open?url=https%3A%2F%2Fno-such-host.invalid%2Ffile.pdf` and nothing running. Crashes before. After, it puts up `No such host is known. (no-such-host.invalid:443)` in 2.8s, same as 1.7.5 on that command. Ordinary PDFs open as before. 256/256 and 1434/1434, no new warnings.

`ThumbCache`, `ThumbCacheFile` and `ThumbCacheComplete` drop writes the same way with no tab open. Left alone, since that is a design call rather than something to bury in a crash fix.

No test. It needs a real window reaching `ContentRendered` with no session, which `KillerPDF.Tests` cannot stand up.
