### PR TITLE
Say why a killerpdf: handoff was refused

### DIFF
--- a/KillerPDF.Tests/ProtocolRegistrarTests.cs
+++ b/KillerPDF.Tests/ProtocolRegistrarTests.cs
@@ -20,4 +20,44 @@ public sealed class ProtocolRegistrarTests
     [InlineData("https://example.com/file.pdf")]
     public void RejectsUnsafeOrUnrelatedLaunches(string value)
         => Assert.False(ProtocolRegistrar.TryGetTargetUrl(value, out _));
+
+    // #267 follow-up: a refusal has to name its branch, or the caller cannot tell a launch that
+    // was aimed at KillerPDF and refused from one that was never a handoff. A table rather than a
+    // Theory because HandoffRejection is internal and cannot sit in a public test signature.
+    [Fact]
+    public void ReportsWhyALaunchWasRefused()
+    {
+        (string Launch, ProtocolRegistrar.HandoffRejection Expected)[] cases =
+        [
+            ("killerpdf://open?url=https%3A%2F%2Fexample.com%2Ffile.pdf",
+                ProtocolRegistrar.HandoffRejection.None),
+            ("killerpdf://open?url=http%3A%2F%2Fexample.com%2Ffile.pdf",
+                ProtocolRegistrar.HandoffRejection.SchemeNotAllowed),
+            ("killerpdf://open?url=file%3A%2F%2Fc%3A%2Fsecret.pdf",
+                ProtocolRegistrar.HandoffRejection.SchemeNotAllowed),
+            ("killerpdf://open?url=notaurl", ProtocolRegistrar.HandoffRejection.MalformedUrl),
+            ("killerpdf://open", ProtocolRegistrar.HandoffRejection.MissingUrl),
+            ("killerpdf://open?other=1", ProtocolRegistrar.HandoffRejection.MissingUrl),
+            ("killerpdf://wrong?url=https%3A%2F%2Fexample.com%2Ffile.pdf",
+                ProtocolRegistrar.HandoffRejection.UnknownCommand),
+            ("https://example.com/file.pdf", ProtocolRegistrar.HandoffRejection.NotAHandoff),
+            (@"C:\missing\file.pdf", ProtocolRegistrar.HandoffRejection.NotAHandoff),
+        ];
+
+        foreach ((string launch, ProtocolRegistrar.HandoffRejection expected) in cases)
+        {
+            ProtocolRegistrar.TryGetTargetUrl(launch, out _, out var rejection);
+            Assert.True(expected == rejection, $"{launch} gave {rejection}, expected {expected}");
+        }
+    }
+
+    [Theory]
+    [InlineData("killerpdf://open?url=https%3A%2F%2Fexample.com%2Ffile.pdf", true)]
+    [InlineData("killerpdf://wrong", true)]
+    [InlineData("KILLERPDF://open", true)]
+    [InlineData("https://example.com/file.pdf", false)]
+    [InlineData(@"C:\missing\file.pdf", false)]
+    [InlineData("", false)]
+    public void IsHandoffLaunchMatchesTheSchemeAndNothingElse(string value, bool expected)
+        => Assert.Equal(expected, ProtocolRegistrar.IsHandoffLaunch(value));
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -468,8 +468,12 @@ namespace KillerPDF
                 FlushPendingExternalOpen();   // a forward that landed before the panes were wired
 
                 var args = Environment.GetCommandLineArgs();
+                // #267 follow-up: route every killerpdf: launch to OpenFromExternal, valid or not.
+                // Gating on a usable target here swallowed a refused handoff before anything could
+                // report it, and restored the last session instead, so a cold launch looked like a
+                // handoff that had simply done nothing.
                 if (args.Length > 1 && (System.IO.File.Exists(args[1]) ||
-                    Services.ProtocolRegistrar.TryGetTargetUrl(args[1], out _)))
+                    Services.ProtocolRegistrar.IsHandoffLaunch(args[1])))
                 {
                     OpenFromExternal(args[1]);
                 }

--- a/Services/ProtocolRegistrar.cs
+++ b/Services/ProtocolRegistrar.cs
@@ -93,12 +93,52 @@ namespace KillerPDF.Services
             try { root.DeleteSubKeyTree(RegistryPath, false); } catch { }
         }
 
+        // #267 follow-up: a refused launch used to fail silently, so the browser handed off, the
+        // app started (or a portable copy extracted its payload first) and nothing appeared. The
+        // caller cannot tell a refusal from a broken install without knowing which branch refused.
+        /// <summary>Why a launch is not a usable browser handoff.</summary>
+        internal enum HandoffRejection
+        {
+            /// <summary>Accepted; there is a target to open.</summary>
+            None,
+            /// <summary>Not a killerpdf: launch at all, so it is not ours to complain about.</summary>
+            NotAHandoff,
+            /// <summary>A killerpdf: launch whose host is something other than "open".</summary>
+            UnknownCommand,
+            /// <summary>killerpdf://open with no url parameter.</summary>
+            MissingUrl,
+            /// <summary>A url parameter that is not an absolute address.</summary>
+            MalformedUrl,
+            /// <summary>An absolute address that is not https.</summary>
+            SchemeNotAllowed,
+        }
+
+        /// <summary>
+        /// True when the argument is a killerpdf: URL, valid or not. The launch paths use this to
+        /// decide whether an argument is aimed at the protocol handler before asking why it failed.
+        /// </summary>
+        internal static bool IsHandoffLaunch(string? argument) =>
+            Uri.TryCreate(argument, UriKind.Absolute, out var launch) &&
+            launch.Scheme.Equals(Scheme, StringComparison.OrdinalIgnoreCase);
+
         internal static bool TryGetTargetUrl(string? protocolUrl, out Uri? target)
+            => TryGetTargetUrl(protocolUrl, out target, out _);
+
+        internal static bool TryGetTargetUrl(
+            string? protocolUrl, out Uri? target, out HandoffRejection rejection)
         {
             target = null;
             if (!Uri.TryCreate(protocolUrl, UriKind.Absolute, out var launch) ||
-                !launch.Scheme.Equals(Scheme, StringComparison.OrdinalIgnoreCase) ||
-                !launch.Host.Equals("open", StringComparison.OrdinalIgnoreCase)) return false;
+                !launch.Scheme.Equals(Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                rejection = HandoffRejection.NotAHandoff;
+                return false;
+            }
+            if (!launch.Host.Equals("open", StringComparison.OrdinalIgnoreCase))
+            {
+                rejection = HandoffRejection.UnknownCommand;
+                return false;
+            }
 
             string query = launch.Query.TrimStart('?');
             foreach (string pair in query.Split('&'))
@@ -108,11 +148,21 @@ namespace KillerPDF.Services
                 string name = Uri.UnescapeDataString(pair[..equals].Replace("+", " "));
                 if (!name.Equals("url", StringComparison.OrdinalIgnoreCase)) continue;
                 string value = Uri.UnescapeDataString(pair[(equals + 1)..].Replace("+", " "));
-                if (!Uri.TryCreate(value, UriKind.Absolute, out var parsed)) return false;
-                if (!parsed.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) return false;
+                if (!Uri.TryCreate(value, UriKind.Absolute, out var parsed))
+                {
+                    rejection = HandoffRejection.MalformedUrl;
+                    return false;
+                }
+                if (!parsed.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                {
+                    rejection = HandoffRejection.SchemeNotAllowed;
+                    return false;
+                }
                 target = parsed;
+                rejection = HandoffRejection.None;
                 return true;
             }
+            rejection = HandoffRejection.MissingUrl;
             return false;
         }
     }

--- a/Shell/ExternalOpen.cs
+++ b/Shell/ExternalOpen.cs
@@ -38,8 +38,36 @@ namespace KillerPDF
                 ActiveViewer.OpenInNewTabExt(path!);
                 return;
             }
-            if (ProtocolRegistrar.TryGetTargetUrl(path, out var target) && target != null)
+            if (ProtocolRegistrar.TryGetTargetUrl(path, out var target, out var rejection) && target != null)
+            {
                 await OpenProtocolUrlAsync(target);
+                return;
+            }
+            // #267 follow-up: say why a killerpdf: launch was refused. Without this the browser
+            // hands off, the app comes up on an empty viewer and nothing explains it. NotAHandoff
+            // stays silent because that is a plain path that simply is not on disk any more.
+            if (rejection != ProtocolRegistrar.HandoffRejection.NotAHandoff)
+                ShowRefusedHandoff(rejection);
+        }
+
+        /// <summary>The same dialog a failed browser download gets, with the refusal as the reason.</summary>
+        private void ShowRefusedHandoff(ProtocolRegistrar.HandoffRejection rejection)
+        {
+            string reason = rejection switch
+            {
+                ProtocolRegistrar.HandoffRejection.UnknownCommand =>
+                    "That browser command is not one KillerPDF knows.",
+                ProtocolRegistrar.HandoffRejection.MissingUrl =>
+                    "The handoff did not include a PDF address.",
+                ProtocolRegistrar.HandoffRejection.MalformedUrl =>
+                    "The PDF address in the handoff could not be read.",
+                ProtocolRegistrar.HandoffRejection.SchemeNotAllowed =>
+                    "KillerPDF only opens browser handoffs over https.",
+                _ => "The browser handoff could not be used.",
+            };
+            KillerDialog.Show(this,
+                $"KillerPDF could not open the browser PDF.\n\n{reason}",
+                "KillerPDF", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
 
         /// <summary>Replay whatever arrived during startup. No-op in the normal case.</summary>

--- a/Shell/ExternalOpen.cs
+++ b/Shell/ExternalOpen.cs
@@ -55,18 +55,14 @@ namespace KillerPDF
         {
             string reason = rejection switch
             {
-                ProtocolRegistrar.HandoffRejection.UnknownCommand =>
-                    "That browser command is not one KillerPDF knows.",
-                ProtocolRegistrar.HandoffRejection.MissingUrl =>
-                    "The handoff did not include a PDF address.",
-                ProtocolRegistrar.HandoffRejection.MalformedUrl =>
-                    "The PDF address in the handoff could not be read.",
-                ProtocolRegistrar.HandoffRejection.SchemeNotAllowed =>
-                    "KillerPDF only opens browser handoffs over https.",
-                _ => "The browser handoff could not be used.",
+                ProtocolRegistrar.HandoffRejection.UnknownCommand => Loc("Str_Handoff_UnknownCommand"),
+                ProtocolRegistrar.HandoffRejection.MissingUrl => Loc("Str_Handoff_MissingUrl"),
+                ProtocolRegistrar.HandoffRejection.MalformedUrl => Loc("Str_Handoff_MalformedUrl"),
+                ProtocolRegistrar.HandoffRejection.SchemeNotAllowed => Loc("Str_Handoff_SchemeNotAllowed"),
+                _ => Loc("Str_Handoff_Unusable"),
             };
             KillerDialog.Show(this,
-                $"KillerPDF could not open the browser PDF.\n\n{reason}",
+                Loc("Str_Handoff_Failed") + "\n\n" + reason,
                 "KillerPDF", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
 

--- a/Strings/bn.xaml
+++ b/Strings/bn.xaml
@@ -960,4 +960,12 @@ Windows সেটিংস - ডিফল্ট অ্যাপ খুলবে�
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/cs-CZ.xaml
+++ b/Strings/cs-CZ.xaml
@@ -965,4 +965,12 @@ Změnit jejich velikost na podporovanou? Stránky si zachovají vzhled i proporc
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/de-DE.xaml
+++ b/Strings/de-DE.xaml
@@ -966,4 +966,12 @@ Auf eine unterstützte Größe skalieren? Aussehen und Proportionen der Seiten b
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/en-US.xaml
+++ b/Strings/en-US.xaml
@@ -980,4 +980,12 @@ Scale them to a supported size? The pages keep their look and proportions.</sys:
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/es.xaml
+++ b/Strings/es.xaml
@@ -960,4 +960,12 @@ Abre Configuración de Windows - Aplicaciones predeterminadas.</sys:String>
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/fr-FR.xaml
+++ b/Strings/fr-FR.xaml
@@ -976,4 +976,12 @@ Les redimensionner à une taille prise en charge ? Les pages conservent leur app
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/hu-HU.xaml
+++ b/Strings/hu-HU.xaml
@@ -967,4 +967,12 @@ Megnyílik a Windows Beállítások - Alapértelmezett alkalmazások.</sys:Strin
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/it-IT.xaml
+++ b/Strings/it-IT.xaml
@@ -980,4 +980,12 @@ Vuoi ridimensionare le pagine ad una dimensione supportata? Le pagine manterrann
     <sys:String x:Key="Str_Compare_ViewDetails">Visualizza rapporto confronto completo</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Controllo di ogni pagina...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">Dettagli confronto PDF</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/ja-JP.xaml
+++ b/Strings/ja-JP.xaml
@@ -965,4 +965,12 @@ Windows の設定 - 既定のアプリ を開きます。</sys:String>
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/pl-PL.xaml
+++ b/Strings/pl-PL.xaml
@@ -968,4 +968,12 @@ Przeskalować je do obsługiwanego rozmiaru? Strony zachowują swój wygląd i p
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/tr-TR.xaml
+++ b/Strings/tr-TR.xaml
@@ -960,4 +960,12 @@ Desteklenen bir boyuta ölçeklensin mi? Sayfaların görünümü ve oranları k
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/zh-CN.xaml
+++ b/Strings/zh-CN.xaml
@@ -964,4 +964,12 @@ KillerPDF 不会创建两个已安装的副本。</sys:String>
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>

--- a/Strings/zh-TW.xaml
+++ b/Strings/zh-TW.xaml
@@ -962,4 +962,12 @@ KillerPDF 不會建立兩個已安裝的複本。</sys:String>
     <sys:String x:Key="Str_Compare_ViewDetails">View complete comparison report</sys:String>
     <sys:String x:Key="Str_Compare_BuildingReport">Checking every page...</sys:String>
     <sys:String x:Key="Str_Compare_DetailsTitle">PDF comparison details</sys:String>
+
+    <!-- ── Browser handoff refusals ────────────────────────────────────── -->
+    <sys:String x:Key="Str_Handoff_Failed">KillerPDF could not open the browser PDF.</sys:String>
+    <sys:String x:Key="Str_Handoff_UnknownCommand">That browser command is not one KillerPDF knows.</sys:String>
+    <sys:String x:Key="Str_Handoff_MissingUrl">The handoff did not include a PDF address.</sys:String>
+    <sys:String x:Key="Str_Handoff_MalformedUrl">The PDF address in the handoff could not be read.</sys:String>
+    <sys:String x:Key="Str_Handoff_SchemeNotAllowed">KillerPDF only opens browser handoffs over https.</sys:String>
+    <sys:String x:Key="Str_Handoff_Unusable">The browser handoff could not be used.</sys:String>
 </ResourceDictionary>


### PR DESCRIPTION
`TryGetTargetUrl` returns a bare `false` for five different reasons, so `ExternalOpen` cannot tell a launch that was aimed at KillerPDF and refused from an argument that was never a handoff. Both get silence. An `http://` handoff hands over, extracts a portable payload if there is one, and leaves the window on the empty `Drop PDF here` state.

`HandoffRejection` names the branch that refused, and `ShowRefusedHandoff` reuses the dialog a failed browser download already gets. No new string to translate: everything in that method is hardcoded English already. `NotAHandoff` still says nothing, since that is an ordinary path that is no longer on disk.

`IsHandoffLaunch` replaces the `TryGetTargetUrl` call in the launch gate at `MainWindow.xaml.cs:471`. Without it a refused URL never reaches `OpenFromExternal` on a cold launch, so the message would only ever appear on a forwarded one.

Tests cover eight refused launches across all five reasons, the accepted case, and the scheme predicate. A table rather than a `[Theory]` because `HandoffRejection` is internal and cannot sit in a public test signature. 263/263, no new warnings.

Wants #276 in first. Routing refusals through `OpenFromExternal` on a cold launch is what that crash sits on, so until it lands this trades a silent no-op for a crash window. Different files, so no conflict.
