### PR TITLE
Accept hybrid-reference PDFs written by Microsoft Office

### DIFF
--- a/engine/KillerPdf.Engine.Tests/CrossReference/PdfCrossReferenceTableTests.cs
+++ b/engine/KillerPdf.Engine.Tests/CrossReference/PdfCrossReferenceTableTests.cs
@@ -777,18 +777,85 @@ public sealed class PdfCrossReferenceTableTests
     }
 
     [Fact]
-    public void Read_RejectsMismatchedHybridRevisionSizes()
+    public void Read_RejectsHybridRevisionSizeAboveItsTrailer()
     {
         PdfSyntaxException error = Assert.Throws<PdfSyntaxException>(() =>
             PdfCrossReferenceTable.Read(
                 HybridReferencePdf(hybridHasPreviousOffset: false, hybridSize: 4)));
 
-        Assert.Contains("stream /Size must match", error.Message,
+        Assert.Contains("stream /Size cannot exceed", error.Message,
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Read_AllowsHybridRevisionSizeBelowItsTrailer()
+    {
+        // Microsoft Excel writes the hybrid stream as the file's last object and
+        // indexes only the objects before it, so the stream's /Size is one less
+        // than the classic trailer's. Both are correct under ISO 32000-1 Table 17,
+        // and the classic table still registers the stream object itself.
+        PdfCrossReferenceTable table = PdfCrossReferenceTable.Read(
+            HybridReferencePdf(
+                hybridHasPreviousOffset: false, hybridSize: 2, hybridIndexCount: 2));
+
+        Assert.Equal(PdfCrossReferenceEntryType.InUse, table[2].Type);
+    }
+
+    [Fact]
+    public void Read_AllowsHybridStreamToReviveObjectsRetiredByItsClassicTable()
+    {
+        // Microsoft Office retires object-stream-resident objects at generation
+        // 65535 in the classic tables so legacy readers skip them, and lists the
+        // same objects as live in the companion stream (ISO 32000-1 7.5.8.4).
+        // That is a compatibility convention, not a generation regression.
+        PdfCrossReferenceTable table =
+            PdfCrossReferenceTable.Read(OfficeStyleHybridPdf());
+
+        Assert.Equal(PdfCrossReferenceEntryType.InUse, table[2].Type);
+    }
+
+    private static byte[] OfficeStyleHybridPdf()
+    {
+        using var source = new MemoryStream();
+        Write("%PDF-1.7\n");
+        int catalogOffset = checked((int)source.Position);
+        Write("1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+        int streamOffset = checked((int)source.Position);
+        byte[] rows =
+        [
+            1, (byte)(catalogOffset >> 24), (byte)(catalogOffset >> 16),
+                (byte)(catalogOffset >> 8), (byte)catalogOffset, 0, 0,
+            1, (byte)(streamOffset >> 24), (byte)(streamOffset >> 16),
+                (byte)(streamOffset >> 8), (byte)streamOffset, 0, 0
+        ];
+        Write("2 0 obj\n<< /Type /XRef /Size 3 /W [1 4 2] /Index [1 2] " +
+            $"/Length {rows.Length} /Root 1 0 R >>\nstream\n");
+        source.Write(rows);
+        Write("\nendstream\nendobj\n");
+
+        // Revision A: the legacy-visible table, which retires object 2.
+        int firstTableOffset = checked((int)source.Position);
+        Write("xref\n0 3\n");
+        Write("0000000002 65535 f\n");
+        Write($"{catalogOffset:0000000000} 00000 n\n");
+        Write("0000000000 65535 f\n");
+        Write("trailer\n<< /Size 3 /Root 1 0 R >>\n");
+        Write($"startxref\n{firstTableOffset}\n%%EOF\n");
+
+        // Revision B: an empty table whose trailer points at both companions.
+        int secondTableOffset = checked((int)source.Position);
+        Write("xref\n0 0\n");
+        Write($"trailer\n<< /Size 3 /Root 1 0 R /Prev {firstTableOffset} " +
+            $"/XRefStm {streamOffset} >>\n");
+        Write($"startxref\n{secondTableOffset}\n%%EOF\n");
+        return source.ToArray();
+
+        void Write(string value) => source.Write(Encoding.ASCII.GetBytes(value));
+    }
+
     private static byte[] HybridReferencePdf(
-        bool hybridHasPreviousOffset, int hybridSize = 3)
+        bool hybridHasPreviousOffset, int hybridSize = 3,
+        int hybridIndexCount = 3)
     {
         using var source = new MemoryStream();
         Write("%PDF-2.0\n");
@@ -803,8 +870,9 @@ public sealed class PdfCrossReferenceTableTests
             1, (byte)(streamOffset >> 24), (byte)(streamOffset >> 16),
                 (byte)(streamOffset >> 8), (byte)streamOffset, 0, 0
         ];
+        rows = rows[..(hybridIndexCount * 7)];
         Write($"2 0 obj\n<< /Type /XRef /Size {hybridSize} /W [1 4 2] " +
-            "/Index [0 3] /Length 21 " +
+            $"/Index [0 {hybridIndexCount}] /Length {rows.Length} " +
             (hybridHasPreviousOffset ? "/Prev 0 " : string.Empty) +
             "/PrivateState << /Enabled false >> >>\nstream\n");
         source.Write(rows);

--- a/engine/KillerPdf.Engine/CrossReference/PdfCrossReferenceTable.cs
+++ b/engine/KillerPdf.Engine/CrossReference/PdfCrossReferenceTable.cs
@@ -167,7 +167,7 @@ public sealed class PdfCrossReferenceTable : IReadOnlyDictionary<int, PdfCrossRe
             currentOffset = primary.PreviousOffset;
         }
 
-        ValidateRevisionSizes(revisions, startXref.Offset, linearization);
+        ValidateRevisionSizes(revisions, startXref.Offset);
         ValidateRevisionGenerations(revisions, startXref.Offset, linearization);
         ValidatePermanentIdentifiers(revisions, startXref.Offset);
         ValidateEncryptionIntroduction(revisions, startXref.Offset);
@@ -299,8 +299,7 @@ public sealed class PdfCrossReferenceTable : IReadOnlyDictionary<int, PdfCrossRe
         || IsLinearizedForwardHybrid(section, linearization);
 
     private static void ValidateRevisionSizes(
-        IReadOnlyList<Revision> revisions, long offset,
-        LinearizationInfo? linearization)
+        IReadOnlyList<Revision> revisions, long offset)
     {
         long previousSize = 0;
         for (int index = revisions.Count - 1; index >= 0; index--)
@@ -315,10 +314,9 @@ public sealed class PdfCrossReferenceTable : IReadOnlyDictionary<int, PdfCrossRe
             {
                 long hybridSize = ((PdfInteger)
                     revision.Hybrid.Trailer[SizeName]).Value;
-                if (hybridSize != size
-                    && !IsLinearizedFirstPageSection(revision.Primary, linearization))
+                if (hybridSize > size)
                     throw new PdfSyntaxException(
-                        "A hybrid cross-reference stream /Size must match its trailer /Size",
+                        "A hybrid cross-reference stream /Size cannot exceed its trailer /Size",
                         ClampOffset(revision.Hybrid.Offset));
             }
             previousSize = size;
@@ -352,7 +350,14 @@ public sealed class PdfCrossReferenceTable : IReadOnlyDictionary<int, PdfCrossRe
                     continue;
                 }
                 bool isFree = entry.Type == PdfCrossReferenceEntryType.Free;
+                // A hybrid companion stream restates the revision's own objects for
+                // readers that understand compressed entries; the classic tables
+                // deliberately retire those same object numbers at generation 65535
+                // so legacy readers skip them (ISO 32000-1 7.5.8.4). That is a
+                // compatibility convention, not an incremental-update generation
+                // sequence, so hybrid entries do not participate in it.
                 if (states.TryGetValue(entry.ObjectNumber, out var previous)
+                    && revision.Hybrid?.ContainsKey(entry.ObjectNumber) != true
                     && !IsLinearizedFirstPageSection(revision.Primary, linearization))
                 {
                     int requiredGeneration = !previous.IsFree && isFree


### PR DESCRIPTION
Word and Excel PDFs are refused on open in 1.8.1 with "has a damaged structure and couldn't be added", and offered for repair.
The files are fine.
Two revision-chain validators read the hybrid-reference compatibility convention as corruption.

I hit this upgrading my own install from 1.7.5 to 1.8.1.

Office writes a classic `xref` table whose trailer carries `/XRefStm` pointing at a companion cross-reference stream.

The companion `/Size` sits one below the trailer's, legitimately.
The stream is the last object and carries no `/Index`, so its section covers `0..n-1` while the trailer covers `0..n` including the stream itself.
One file here: trailer `/Size 356`, companion `355 0 obj` with `/Size 355`.
ISO 32000-1 Table 17 makes both correct, so the gap is structural.
`ValidateRevisionSizes` demanded equality.
A companion section is always a subset of its revision, so it can never exceed the trailer's high-water mark but can fall short.
`hybridSize > size` is the whole rule, and it subsumes the linearized carve-out, which existed only to permit that same smaller range.

Objects are also retired at generation 65535 on purpose.
Office frees object-stream-resident objects, and the streams holding them, in the classic tables so legacy readers skip them, then lists those same objects as live in the companion.
`ValidateRevisionGenerations` compared the companion against that retired state and reported "generation cannot decrease".
Hybrid entries no longer take part in that sequence.
Entries reached through the classic tables are validated exactly as before.

Of 41 files here, 13 are hybrid and 4 tripped it, all Word: 2010, 2016 and Office 365.
The four Excel files that started this tripped it too.
The 9 Adobe PDF Library hybrids declare an equal `/Size` and were never affected, so this does not wave the whole class through.
All 41 parse with the patch, and the render is byte-identical by SHA-256 to what 1.8.1 already produced through its own "rendering as-is" fallback, so only the open path was refusing.

Engine 1438/1438 and app 272/272, with each new test confirmed to fail without its source change.
`Read_AllowsLinearizedFirstPageTableToPointForwardToHybridStream` already builds trailer `/Size 3` against companion `/Size 2`, so it covers the carve-out removal directly.

Left alone deliberately: both changelogs, since you curate those at release, and the repair dialog, which behaves fine and was only being handed good files.
I have not tried PowerPoint or Office versions beyond the four above.

One call is yours.
I exempted hybrid entries from generation validation wholesale, on the grounds that a companion restates its revision's objects rather than revising them.
The narrower option is to exempt only where the previous state is a 65535 retirement.
Say so and I will tighten it.
