### PR TITLE
Keep the OS resize borders and strip only the caption

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="KillerPDF" Height="700" Width="1000" MinHeight="480" MinWidth="620"
         WindowStartupLocation="CenterScreen"
-        WindowStyle="None"
+        WindowStyle="SingleBorderWindow"
         ResizeMode="CanResize"
         Background="{DynamicResource SurfaceBrush}"
         FontFamily="{DynamicResource UiFont}"
@@ -17,19 +17,7 @@
         UseLayoutRounding="True"
         SnapsToDevicePixels="True">
 
-    <!-- Hardware-accelerated custom chrome. Dropping AllowsTransparency lets WPF composite the
-         whole window on the GPU again (the film grain + drop shadows were being software-rendered
-         every frame, which made dragging/animation jumpy). WindowChrome gives native drag, snap,
-         resize and the OS drop shadow; the title bar (row 0) becomes the caption and the
-         min/max/close buttons opt back into hit-testing with IsHitTestVisibleInChrome. -->
-    <WindowChrome.WindowChrome>
-        <WindowChrome CaptionHeight="{DynamicResource TitleBarHeight}"
-                      ResizeBorderThickness="12"
-                      CornerRadius="0"
-                      GlassFrameThickness="0"
-                      NonClientFrameEdges="None"
-                      UseAeroCaptionButtons="False"/>
-    </WindowChrome.WindowChrome>
+    <!-- Real OS frame with the caption stripped in Shell/WindowChrome.cs; row 0 is the caption. -->
 
     <Window.Resources>
         <ResourceDictionary>
@@ -1327,8 +1315,7 @@
         </Grid.RowDefinitions>
 
         <!-- Title bar -->
-        <!-- WindowChrome.CaptionHeight makes this row the draggable caption (native drag + double-click
-             maximize), so the explicit MouseLeftButtonDown drag handler is no longer wired. -->
+        <!-- Native caption via WM_NCHITTEST, so no drag handler is wired. -->
         <Border Grid.Row="0" x:Name="TitleBarBorder" Height="{DynamicResource TitleBarHeight}"
                 Background="{DynamicResource TitleBarBrush}" BorderThickness="0"
                 CornerRadius="{DynamicResource TitleBarCornerRadius}">
@@ -1344,7 +1331,6 @@
                      drive the app-wide size (AppScale.cs); that opts it out of the native
                      caption, so drag / double-click-maximize come back via LogoBar handlers. -->
                 <Border x:Name="LogoBar" Grid.Column="0" Background="Transparent"
-                        WindowChrome.IsHitTestVisibleInChrome="True"
                         ToolTip="{DynamicResource Str_TT_AppSize}"
                         MouseWheel="LogoBar_MouseWheel"
                         MouseLeftButtonDown="LogoBar_MouseLeftButtonDown">
@@ -1377,8 +1363,7 @@
                            Foreground="{DynamicResource FilenameBrush}" FontFamily="Consolas" FontSize="11"/>
                 <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="{DynamicResource CaptionButtonsMargin}">
                     <Button Click="MinimizeBtn_Click" Style="{StaticResource ChromeButton}"
-                            Foreground="{DynamicResource CaptionGlyphBrush}"
-                            WindowChrome.IsHitTestVisibleInChrome="True">
+                            Foreground="{DynamicResource CaptionGlyphBrush}">
                         <Grid Height="{DynamicResource CaptionButtonHeight}">
                             <TextBlock Text="&#xE921;" FontFamily="Segoe MDL2 Assets" FontSize="10"
                                        HorizontalAlignment="Center" VerticalAlignment="Center"
@@ -1391,8 +1376,7 @@
                         </Grid>
                     </Button>
                     <Button Click="MaximizeBtn_Click" Style="{StaticResource ChromeButton}"
-                            Foreground="{DynamicResource CaptionGlyphBrush}"
-                            WindowChrome.IsHitTestVisibleInChrome="True">
+                            Foreground="{DynamicResource CaptionGlyphBrush}">
                         <Grid>
                             <TextBlock Text="&#xE922;" FontFamily="Segoe MDL2 Assets" FontSize="10"
                                        FontWeight="{DynamicResource CaptionGlyphWeight}"
@@ -1405,8 +1389,7 @@
                             </Grid>
                         </Grid>
                     </Button>
-                    <Button Click="CloseBtn_Click" Style="{StaticResource ChromeCloseButton}"
-                            WindowChrome.IsHitTestVisibleInChrome="True"/>
+                    <Button Click="CloseBtn_Click" Style="{StaticResource ChromeCloseButton}"/>
                 </StackPanel>
             </Grid>
             </Grid>
@@ -1415,8 +1398,7 @@
         <!-- Toolbar -->
         <!-- Keep the toolbar explicitly in the client hit-test area. This is also a safety net for
              compact titlebar themes: native caption pixels must never swallow toolbar input. -->
-        <Border Grid.Row="1" x:Name="ToolbarRowBorder" Background="{DynamicResource BackgroundBrush}"
-                WindowChrome.IsHitTestVisibleInChrome="True">
+        <Border Grid.Row="1" x:Name="ToolbarRowBorder" Background="{DynamicResource BackgroundBrush}">
             <Grid>
             <Border IsHitTestVisible="False" Opacity="{DynamicResource GrainOpacity}" Background="{StaticResource GrainBrushShared}"/>
             <!-- Background=Transparent is load-bearing: without it the grid's empty stretches have no
@@ -2675,7 +2657,6 @@
                 <!-- Portable install action sits immediately left of the document controls. -->
                 <Grid x:Name="PortableBadge" Grid.Column="1" Panel.ZIndex="3"
                       HorizontalAlignment="Right" VerticalAlignment="Center"
-                      WindowChrome.IsHitTestVisibleInChrome="True"
                       Margin="6,0,8,0" Visibility="Collapsed">
                     <Button x:Name="InstallBtn" Content="{DynamicResource Str_Portable}"
                             Click="Install_Click" Style="{StaticResource OutlineButton}"
@@ -2691,8 +2672,7 @@
                     </Button>
                 </Grid>
                 <Grid x:Name="FooterDocumentControls" Grid.Column="2"
-                      HorizontalAlignment="Right" Margin="{DynamicResource FooterCellMargin}"
-                      WindowChrome.IsHitTestVisibleInChrome="True">
+                      HorizontalAlignment="Right" Margin="{DynamicResource FooterCellMargin}">
                     <Border IsHitTestVisible="False" BorderBrush="{DynamicResource FooterBevelDarkBrush}"
                             BorderThickness="{DynamicResource FooterCellLightThickness}" Panel.ZIndex="2"/>
                     <Border IsHitTestVisible="False" BorderBrush="{DynamicResource FooterBevelLightBrush}"

--- a/Shell/AppScale.cs
+++ b/Shell/AppScale.cs
@@ -38,9 +38,8 @@ namespace KillerPDF
             e.Handled = true;
         }
 
-        // The logo is marked IsHitTestVisibleInChrome (MainWindow.xaml) so the scroll wheel
-        // reaches it for the zoom above - but that also takes it out of WindowChrome's native
-        // caption, so window drag and double-click-maximize are restored here by hand.
+        // The logo is a client hit (for the wheel above), not caption, so drag and
+        // double-click-maximize are restored here by hand.
         private void LogoBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             if (e.ClickCount == 2)

--- a/Shell/WindowChrome.cs
+++ b/Shell/WindowChrome.cs
@@ -178,6 +178,10 @@ namespace KillerPDF
             try
             {
                 var pt  = PointFromScreen(new Point(screenX, screenY));
+                // WM_NCHITTEST fires on every mouse move, so only walk the tree inside the bar.
+                var bar = TitleBarBorder.TransformToAncestor(this)
+                                        .TransformBounds(new Rect(TitleBarBorder.RenderSize));
+                if (!bar.Contains(pt)) return false;
                 var res = VisualTreeHelper.HitTest(this, pt);
                 DependencyObject? hit = res?.VisualHit;
                 bool inTitleBar = false;

--- a/Shell/WindowChrome.cs
+++ b/Shell/WindowChrome.cs
@@ -40,6 +40,16 @@ namespace KillerPDF
             // Alt+Space before anything else, or Windows draws its stock white HMENU.
             if (TryHandleSystemMenu(msg, wParam, lParam)) { handled = true; return IntPtr.Zero; }
 
+            if (msg == WM_NCCALCSIZE)
+            {
+                handled = WmNcCalcSize(hwnd, wParam, lParam);
+                return IntPtr.Zero;
+            }
+            if (msg == WM_NCHITTEST)
+            {
+                handled = true;
+                return new IntPtr(WmNcHitTest(hwnd, msg, wParam, lParam));
+            }
             if (msg == WM_ERASEBKGND)
             {
                 // WPF paints the whole client area itself, so let nothing erase the background to a flat
@@ -95,68 +105,92 @@ namespace KillerPDF
                         if (idx >= 0) ActiveViewer.RenderPage(idx);
                     }));
             }
-            // WM_NCHITTEST is handled natively by WindowChrome.ResizeBorderThickness. The document scrollbar
-            // is kept grabbable over the right resize band via WindowChrome.IsHitTestVisibleInChrome on the
-            // ScrollBar style (App.xaml), which is the WindowChrome-native way to exempt an element from the
-            // resize border - no manual hit-test override (that fought WindowChrome and killed scrollbar clicks).
             return IntPtr.Zero;
         }
 
-        private int WmNcHitTest(IntPtr hwnd, IntPtr lParam)
+        // ------------------------------------------------------------
+        // Frame: real OS borders, custom caption
+        // ------------------------------------------------------------
+        // No WindowChrome. Windows owns the left, right and bottom borders; WM_NCCALCSIZE strips
+        // only the caption so the title bar row sits at the top of the client area. Owning every
+        // edge ourselves made a top or left drag jitter.
+
+        private int _osFrameWidth;   // width of the OS border at the current DPI, from WM_NCCALCSIZE
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NCCALCSIZE_PARAMS { public RECT rgrc0, rgrc1, rgrc2; public IntPtr lppos; }
+
+        // Handles the wParam == TRUE form only.
+        private bool WmNcCalcSize(IntPtr hwnd, IntPtr wParam, IntPtr lParam)
         {
-            // lParam is screen coords: lo-word = X, hi-word = Y.
-            // Cast through short to preserve sign (handles negative coords on left/above primary monitor).
-            long lp  = lParam.ToInt64();
-            int  mx  = unchecked((short)(lp & 0xFFFF));
-            int  my  = unchecked((short)((lp >> 16) & 0xFFFF));
-
-            if (!GetWindowRect(hwnd, out RECT rc)) return 0;
-
-            // The floating window has a transparent ShadowMargin around the visible content, so the resize
-            // grips must sit at the CONTENT edge (inset by the margin), not the window edge - otherwise you
-            // have to reach out into the shadow to resize. Maximized/snapped has no margin.
-            int sm = _chromeSquared ? 0 : (int)ShadowMargin;
-            bool onLeft   = mx >= rc.left   + sm                 && mx <  rc.left   + sm + ResizeBorder;
-            bool onRight  = mx <  rc.right  - sm                 && mx >= rc.right  - sm - ResizeBorder;
-            bool onTop    = my >= rc.top    + sm                 && my <  rc.top    + sm + ResizeBorder;
-            bool onBottom = my <  rc.bottom - sm                 && my >= rc.bottom - sm - ResizeBorder;
-
-            // Never hijack a scrollbar for window resizing. The vertical scrollbar sits flush
-            // against the window's right edge, so the resize border used to swallow it - the
-            // cursor showed the resize arrow and dragging resized the window instead of moving
-            // the thumb. If a ScrollBar is under the cursor, report client area so it stays grabbable.
-            if ((onLeft || onRight || onTop || onBottom) && IsOverScrollBar(mx, my))
-                return HTCLIENT;
-
-            if (onTop    && onLeft)  return HTTOPLEFT;
-            if (onTop    && onRight) return HTTOPRIGHT;
-            if (onBottom && onLeft)  return HTBOTTOMLEFT;
-            if (onBottom && onRight) return HTBOTTOMRIGHT;
-            if (onLeft)              return HTLEFT;
-            if (onRight)             return HTRIGHT;
-            if (onTop)               return HTTOP;
-            if (onBottom)            return HTBOTTOM;
-
-            return 0;
+            if (wParam == IntPtr.Zero) return false;
+            var p    = Marshal.PtrToStructure<NCCALCSIZE_PARAMS>(lParam);
+            var orig = p.rgrc0;                                  // proposed window rect
+            if (WindowState == WindowState.Maximized || _fullScreen)
+            {
+                // Maximized: the OS hangs the border off screen, so clip the client to the work area.
+                IntPtr monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                if (monitor == IntPtr.Zero) return true;
+                var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+                if (!GetMonitorInfo(monitor, ref info)) return true;
+                RECT b = _fullScreen ? info.rcMonitor : info.rcWork;
+                p.rgrc0.left   = Math.Max(orig.left,   b.left);
+                p.rgrc0.top    = Math.Max(orig.top,    b.top);
+                p.rgrc0.right  = Math.Min(orig.right,  b.right);
+                p.rgrc0.bottom = Math.Min(orig.bottom, b.bottom);
+                Marshal.StructureToPtr(p, lParam, false);
+                return true;
+            }
+            DefWindowProc(hwnd, WM_NCCALCSIZE, wParam, lParam);  // OS lays out the full frame
+            p = Marshal.PtrToStructure<NCCALCSIZE_PARAMS>(lParam);
+            _osFrameWidth = p.rgrc0.left - orig.left;
+            p.rgrc0.top   = orig.top;                            // drop the caption, keep the sides
+            Marshal.StructureToPtr(p, lParam, false);
+            return true;
         }
 
-        // Hit-tests the visual tree at a screen point (physical pixels from WM_NCHITTEST)
-        // and reports whether a ScrollBar sits under the cursor.
-        private bool IsOverScrollBar(int screenX, int screenY)
+        private int WmNcHitTest(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam)
+        {
+            // Let the OS answer for its own borders first.
+            int def = DefWindowProc(hwnd, msg, wParam, lParam).ToInt32();
+            if (def != HTCLIENT) return def;
+
+            // Screen coords; short cast keeps the sign on monitors left of or above the primary.
+            long lp = lParam.ToInt64();
+            int  mx = unchecked((short)(lp & 0xFFFF));
+            int  my = unchecked((short)((lp >> 16) & 0xFFFF));
+
+            // The top edge lost its OS border with the caption, so give it a grip of the same width.
+            if (WindowState != WindowState.Maximized && !_fullScreen && _osFrameWidth > 0
+                && GetWindowRect(hwnd, out RECT rc) && my < rc.top + _osFrameWidth)
+            {
+                if (mx <  rc.left  + _osFrameWidth) return HTTOPLEFT;
+                if (mx >= rc.right - _osFrameWidth) return HTTOPRIGHT;
+                return HTTOP;
+            }
+
+            return IsCaptionAt(mx, my) ? HTCAPTION : HTCLIENT;
+        }
+
+        // Title-bar row is the caption, except over a control or the logo (scroll-wheel scaling).
+        private bool IsCaptionAt(int screenX, int screenY)
         {
             try
             {
                 var pt  = PointFromScreen(new Point(screenX, screenY));
                 var res = VisualTreeHelper.HitTest(this, pt);
                 DependencyObject? hit = res?.VisualHit;
+                bool inTitleBar = false;
                 while (hit != null)
                 {
-                    if (hit is System.Windows.Controls.Primitives.ScrollBar) return true;
+                    if (hit is Control && !ReferenceEquals(hit, this)) return false;
+                    if (ReferenceEquals(hit, LogoBar))        return false;
+                    if (ReferenceEquals(hit, TitleBarBorder)) inTitleBar = true;
                     hit = VisualTreeHelper.GetParent(hit);
                 }
+                return inTitleBar;
             }
-            catch { /* best-effort; fall through to normal resize handling */ }
-            return false;
+            catch { return false; }   // not laid out yet; treat as client
         }
 
         private void WmGetMinMaxInfo(IntPtr hwnd, IntPtr lParam)
@@ -212,8 +246,12 @@ namespace KillerPDF
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetWindowRect(IntPtr hwnd, out RECT rect);
 
+        [LibraryImport("user32.dll", EntryPoint = "DefWindowProcW")]
+        private static partial IntPtr DefWindowProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam);
+
         private const int WM_NCLBUTTONDOWN = 0x00A1;
         private const int WM_NCHITTEST     = 0x0084;
+        private const int WM_NCCALCSIZE    = 0x0083;
         private const int HTCLIENT         = 1;
         private const int HTCAPTION        = 2;
         private const int HTLEFT           = 10;

--- a/Shell/WindowChrome.cs
+++ b/Shell/WindowChrome.cs
@@ -488,7 +488,8 @@ namespace KillerPDF
         private void UpdateWindowChrome()
         {
             bool max     = WindowState == WindowState.Maximized || _fullScreen;
-            bool squared = max || IsSnapped() || ThemeManager.Current == Theme.SE98;
+            // Only Windows 11 rounds the HWND; on Windows 10 rounded content would show a notch.
+            bool squared = max || IsSnapped() || ThemeManager.Current == Theme.SE98 || !OsRoundsCorners();
             _chromeSquared = squared;
 
             // The chrome treatment depends ONLY on the maximized/snapped state, not on the live size
@@ -556,12 +557,27 @@ namespace KillerPDF
                 var hwnd = new WindowInteropHelper(this).Handle;
                 if (hwnd == IntPtr.Zero) return;
                 int pref = rounded ? DWMWCP_ROUND : DWMWCP_DONOTROUND;
-                _ = DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref pref, sizeof(int));
+                int hr = DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref pref, sizeof(int));
+                _osRoundsCorners = hr == 0;
             }
-            catch { /* pre-Win11 DWM: attribute unsupported, square corners */ }
+            catch { _osRoundsCorners = false; }   // pre-Win11 DWM: attribute unsupported, square corners
+        }
+
+        // Probed once; Windows 10 rejects the corner attribute.
+        private bool? _osRoundsCorners;
+        private bool OsRoundsCorners()
+        {
+            if (_osRoundsCorners is bool known) return known;
+            var hwnd = new WindowInteropHelper(this).Handle;
+            if (hwnd == IntPtr.Zero) return true;            // no HWND yet; decide on the first real pass
+            int pref = DWMWCP_DEFAULT;
+            try { _osRoundsCorners = DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref pref, sizeof(int)) == 0; }
+            catch { _osRoundsCorners = false; }
+            return _osRoundsCorners.Value;
         }
 
         private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
+        private const int DWMWCP_DEFAULT    = 0;
         private const int DWMWCP_DONOTROUND = 1;
         private const int DWMWCP_ROUND      = 2;
 


### PR DESCRIPTION
Dragging the top or left edge of the main window on 1.8.4 makes the whole UI jitter.
Right and bottom are fine, and it happens with no document open.

Those two edges move the window origin.
With `WindowChrome` owning every edge, the compositor shows the last frame at the new origin before WPF paints the next one, so anything anchored right or bottom jumps for a tick.
`SWP_NOCOPYBITS`, `WVR_REDRAW`, `GlassFrameThickness` and `ResizeBorderThickness` made no difference.
A stock `SingleBorderWindow` fixed it.

So the main window is now a `SingleBorderWindow` with no `WindowChrome`.
Windows draws and hit-tests the left, right and bottom borders.
`WM_NCCALCSIZE` in `Shell/WindowChrome.cs` strips only the caption band, so the title bar row sits at the top of the client area.
`WM_NCHITTEST` lets the OS answer for its borders, gives the top edge a grip the same width as the sides, and reports the title bar as `HTCAPTION` except over a control.
Drag, snap, double-click maximize, the system menu and the logo's scroll-wheel scaling all still work.
A maximized window is clipped to the work area (the monitor for F11) so nothing hangs off screen.
The window is still an opaque GPU-composited HWND, so shadow, DWM corners and grain are unchanged.
The `IsHitTestVisibleInChrome` attributes and the unused `WmNcHitTest` are gone.

Second commit, easy to split out: on Windows 10 the DWM corner preference is rejected, so the HWND is square but the content was still rounded, leaving a notch in each corner.
`UpdateWindowChrome` now probes the attribute once and squares the content when the OS can't round it.
This was there with the old chrome too.

Tested on one Windows 10 machine (19045), .NET SDK 10.0.400, `dotnet build -c Release`:

- all edges and corners, in Continuous and Single, and with no document
- title bar drag, double-click, drag-down restore, Alt+Space, right-click menu, wheel over the logo
- Win+Left, Win+Right, edge snap, maximize, F11
- Dark, Light, Black, a textured theme and 98SE
- app scaling up and back to Ctrl+Shift+0
- split panes and a window at minimum size

Not tested on Windows 11, so the rounded-corner path of the second commit is untried there.
`dev/1.9-overkill` has the same chrome code, so this should apply there as well.
