### PR TITLE
Keep the comparison chip's label readable on its own background

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2552,16 +2552,16 @@
                             <StackPanel Orientation="Horizontal">
                                 <Grid Width="15" Height="13" Margin="0,1,7,0" VerticalAlignment="Center">
                                     <Border Width="6" Height="11" HorizontalAlignment="Left" VerticalAlignment="Center"
-                                            BorderBrush="{DynamicResource SelectionFg}" BorderThickness="1" CornerRadius="1">
-                                        <Rectangle Height="1" Margin="1" VerticalAlignment="Center" Fill="{DynamicResource SelectionFg}"/>
+                                            BorderBrush="{DynamicResource OnPrimaryBrush}" BorderThickness="1" CornerRadius="1">
+                                        <Rectangle Height="1" Margin="1" VerticalAlignment="Center" Fill="{DynamicResource OnPrimaryBrush}"/>
                                     </Border>
                                     <Border Width="6" Height="11" HorizontalAlignment="Right" VerticalAlignment="Center"
-                                            BorderBrush="{DynamicResource SelectionFg}" BorderThickness="1" CornerRadius="1">
-                                        <Rectangle Height="1" Margin="1" VerticalAlignment="Center" Fill="{DynamicResource SelectionFg}"/>
+                                            BorderBrush="{DynamicResource OnPrimaryBrush}" BorderThickness="1" CornerRadius="1">
+                                        <Rectangle Height="1" Margin="1" VerticalAlignment="Center" Fill="{DynamicResource OnPrimaryBrush}"/>
                                     </Border>
                                 </Grid>
                                 <TextBlock Text="{DynamicResource Str_Compare_Bar}" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource SelectionFg}" VerticalAlignment="Center"/>
+                                           Foreground="{DynamicResource OnPrimaryBrush}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="1" Padding="6,2,4,2">


### PR DESCRIPTION
The COMPARISON chip fills with `PrimaryBrush` and drew its label and both document icons in `SelectionFg`, which is the foreground that pairs with `SelectionBg`.
The one that pairs with `PrimaryBrush` is `OnPrimaryBrush`, as `UiKit.cs:482` has it.
Five references at `MainWindow.xaml:2550-2566`.

#371 puts this at two themes, which undercounts it; there's a correction on the issue.
Accents override `PrimaryBrush` as well, so the unit is the theme and accent pair. Contrast of the label against the chip:

```
theme       accent     before    after
Cyanotic    (none)       1.00    15.69
Greed       (none)       1.00    14.92
Black       Teal         1.27    15.53
Black       (none)       1.36    14.61
Blood       (none)       1.52    11.63
Decay       (none)       2.09     6.86
Malaise     (none)       2.40     5.29
Dark        Blue         2.45     8.07
Dark        Teal         2.48     7.99
Sepulchre   (none)       2.75     5.74
Dark        Purple       2.85     6.94
Dark        (none)       3.21     6.17
Black       Blue         3.31     5.98
Black       Red          3.75     5.28
Dark        Red          3.94     5.02
Black       Purple       4.38     4.52
Dark        Orange       6.93     8.32
Black       Orange       7.30     8.77
```

The other 16 combinations already have `SelectionFg` and `OnPrimaryBrush` set to the same colour, so they don't move.
Of the 18 that do, every one goes up and none go down. Greed and Cyanotic are the 1.00 pair, where the two brushes are the same white.

The visible change is wider than the bug: the label flips from light to dark in most themes, which is what `OnPrimaryBrush` is for but is still a look you may have picked deliberately.

Built off `4827666` on .NET SDK 10.0.400, suites green at 1465 and 301.
Shot the bar in Greed, Cyanotic and Dark on the Red accent.

Ratios are WCAG relative luminance, so they describe the contrast and not whether 12px semibold small caps needs 4.5 or 3.
