### PR TITLE
Keep underscores in the compare menu's file names

### DIFF
--- a/Shell/PdfComparison.cs
+++ b/Shell/PdfComparison.cs
@@ -124,7 +124,9 @@ public partial class MainWindow
             foreach (var tab in openTabs)
             {
                 string path = tab.Path;
-                var item = new MenuItem { Header = tab.Title };
+                // Doubled for the same reason as the tab overflow menu: a lone underscore
+                // in a string MenuItem header is an access-key marker (PdfViewer.TabStrip.cs).
+                var item = new MenuItem { Header = tab.Title.Replace("_", "__") };
                 item.Click += (_, _) => BeginComparison(source, path);
                 items.Add(item);
             }


### PR DESCRIPTION
A string `MenuItem` header treats a lone underscore as an access-key marker, so `Q3_Report_Draft.pdf` listed as `Q3Report_Draft.pdf` in the compare menu.

The tab overflow menu already doubles them for this (`Controls/Viewer/PdfViewer.TabStrip.cs:291`), so this is the same call on the one site that missed it (`Shell/PdfComparison.cs:127`).
The recent files menu needs nothing, since it replaces `Header` with a Grid and the name is a TextBlock.

Built off `4827666` on .NET SDK 10.0.400. The menu reads `Q3_Report_Draft.pdf` after.

Detail in #376.
