### PR TITLE
Render the primary page when a document is bootstrapped

### DIFF
--- a/Controls/Viewer/PdfViewer.Viewport.cs
+++ b/Controls/Viewer/PdfViewer.Viewport.cs
@@ -1366,6 +1366,11 @@ namespace KillerPDF.Controls
                 if (isContinuous)
                     Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Loaded,
                         () => SetupContinuousView(page, fitDefault: autoFit, restoreVerticalOffset));
+                // RefreshPageList re-seats the sidebar under _syncingPageList, so the selection
+                // handler never renders the primary for a new document. Render it here, or the
+                // previous tab's page stays on screen in Single, Two-Page and Grid.
+                else
+                    RenderPage(_viewMode == ViewMode.Grid ? 0 : page);
                 // Fit / zoom once the first page has rendered and layout has settled.
                 // DispatcherPriority.Background is lower than Loaded, so this fires after
                 // all pending RenderPage / RefreshPageView callbacks have completed.


### PR DESCRIPTION
For #378.

`BootstrapDocumentView` renders the primary itself in the non-continuous modes, page 0 in Grid and the target page otherwise, rather than leaning on `PageList_SelectionChanged`, which has returned early under `_syncingPageList` since #301.

Checked on a local install of this branch: Grid tab switches between two documents at page 1, and opening a third file from Explorer while in Grid. Release build clean, 301/301 app tests.

Spot-checked Single and Two-Page only. Pane B, comparison mode and the other themes not exercised.

One side effect worth knowing: on a fresh open the primary now renders here and again from the re-sharpen timer, which is what happened before 1.8.3 anyway. If you'd rather not pay that twice I can gate the timer instead.
