### PR TITLE
Fix Italian translation for Stamp

### DIFF
--- a/Strings/it-IT.xaml
+++ b/Strings/it-IT.xaml
@@ -294,7 +294,7 @@ Vuoi ridimensionare le pagine ad una dimensione supportata? Le pagine manterrann
     <sys:String x:Key="Str_Lbl_Crop">Ritaglia</sys:String>
     <sys:String x:Key="Str_Lbl_Measure">Misura</sys:String>
     <sys:String x:Key="Str_Lbl_Rotate">Trasforma</sys:String>
-    <sys:String x:Key="Str_Lbl_Stamp">Stampa</sys:String>
+    <sys:String x:Key="Str_Lbl_Stamp">Marcatura</sys:String>
     <sys:String x:Key="Str_Lbl_Image">Aggiungi immagine</sys:String>
     <sys:String x:Key="Str_Lbl_Signature">Firma</sys:String>
     <sys:String x:Key="Str_Lbl_Undo">Annulla</sys:String>


### PR DESCRIPTION
The Italian localization used "Stampa" for both Print and Stamp.

Since the Stamp tool handles page markings such as watermarks and page numbers, rename it to "Marcatura" to avoid ambiguity with the Print command.

Only Str_Lbl_Stamp is changed.